### PR TITLE
fix(dns): Filter used ip when use dns nodes

### DIFF
--- a/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
+++ b/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
@@ -104,6 +104,7 @@ public class ConnPoolService extends P2pEventHandler {
         nodesInUse.add(channel.getNodeId());
       }
       addressInUse.add(channel.getInetAddress());
+      inetInUse.add(channel.getInetSocketAddress());
       addNode(inetInUse, channel.getNode());
     });
 
@@ -158,6 +159,7 @@ public class ConnPoolService extends P2pEventHandler {
         if (validNode(node, nodesInUse, inetInUse)) {
           DnsNode copyNode = (DnsNode) node.clone();
           copyNode.setId(NetUtil.getNodeId());
+          inetInUse.add(copyNode.getPreferInetSocketAddress());
           filtered.add(copyNode);
         }
       }

--- a/src/main/java/org/tron/p2p/discover/Node.java
+++ b/src/main/java/org/tron/p2p/discover/Node.java
@@ -149,7 +149,7 @@ public class Node implements Serializable, Cloneable {
   @Override
   public String toString() {
     return "Node{" + " hostV4='" + hostV4 + '\'' + ", hostV6='" + hostV6 + '\'' + ", port=" + port
-      + ", id=" + Hex.toHexString(id) + '}';
+        + ", id=\'" + (id == null ? "null" : Hex.toHexString(id)) + "\'}";
   }
 
   public String format() {

--- a/src/main/java/org/tron/p2p/discover/socket/P2pPacketDecoder.java
+++ b/src/main/java/org/tron/p2p/discover/socket/P2pPacketDecoder.java
@@ -7,6 +7,7 @@ import io.netty.channel.socket.DatagramPacket;
 import io.netty.handler.codec.MessageToMessageDecoder;
 import lombok.extern.slf4j.Slf4j;
 import org.tron.p2p.discover.message.Message;
+import org.tron.p2p.exception.P2pException;
 
 @Slf4j(topic = "net")
 public class P2pPacketDecoder extends MessageToMessageDecoder<DatagramPacket> {
@@ -27,9 +28,17 @@ public class P2pPacketDecoder extends MessageToMessageDecoder<DatagramPacket> {
     try {
       UdpEvent event = new UdpEvent(Message.parse(encoded), packet.sender());
       out.add(event);
+    } catch (P2pException pe) {
+      if (pe.getType().equals(P2pException.TypeEnum.BAD_MESSAGE)) {
+        log.error("Message validation failed, type {}, len {}, address {}", encoded[0],
+            encoded.length, packet.sender());
+      } else {
+        log.info("Parse msg failed, type {}, len {}, address {}", encoded[0], encoded.length,
+            packet.sender());
+      }
     } catch (Exception e) {
-      log.error("Parse msg failed, type {}, len {}, address {}", encoded[0], encoded.length,
-          packet.sender());
+      log.error("An exception occurred while parsing the message, type {}, len {}, address {}",
+          encoded[0], encoded.length, packet.sender(), e);
     }
   }
 }

--- a/src/main/java/org/tron/p2p/dns/DnsManager.java
+++ b/src/main/java/org/tron/p2p/dns/DnsManager.java
@@ -45,12 +45,19 @@ public class DnsManager {
     Set<DnsNode> nodes = new HashSet<>();
     for (Map.Entry<String, Tree> entry : syncClient.getTrees().entrySet()) {
       Tree tree = entry.getValue();
-      log.debug("tree:{} node size:{}", entry.getKey(), tree.getDnsNodes().size());
+      int v6Size = 0;
       List<DnsNode> dnsNodes = tree.getDnsNodes();
+      List<DnsNode> ipv6Nodes = new ArrayList<>();
       for (DnsNode dnsNode : dnsNodes) {
         if (dnsNode.getInetSocketAddressV6() != null) {
-          log.debug(dnsNode.format());
+          v6Size += 1;
+          ipv6Nodes.add(dnsNode);
         }
+      }
+      log.debug("Tree {} node size:{}, v6 node size:{}", entry.getKey(), tree.getDnsNodes().size(),
+          v6Size);
+      if (ipv6Nodes.size() > 0) {
+        log.debug("Node with ipv6: {}", ipv6Nodes);
       }
       List<DnsNode> connectAbleNodes = dnsNodes.stream()
           .filter(node -> node.getPreferInetSocketAddress() != null)

--- a/src/main/java/org/tron/p2p/dns/DnsManager.java
+++ b/src/main/java/org/tron/p2p/dns/DnsManager.java
@@ -45,17 +45,20 @@ public class DnsManager {
     Set<DnsNode> nodes = new HashSet<>();
     for (Map.Entry<String, Tree> entry : syncClient.getTrees().entrySet()) {
       Tree tree = entry.getValue();
-      int v6Size = 0;
+      int v4Size = 0, v6Size = 0;
       List<DnsNode> dnsNodes = tree.getDnsNodes();
       List<DnsNode> ipv6Nodes = new ArrayList<>();
       for (DnsNode dnsNode : dnsNodes) {
+        if (dnsNode.getInetSocketAddressV4() != null) {
+          v4Size += 1;
+        }
         if (dnsNode.getInetSocketAddressV6() != null) {
           v6Size += 1;
           ipv6Nodes.add(dnsNode);
         }
       }
-      log.debug("Tree {} node size:{}, v6 node size:{}", entry.getKey(), tree.getDnsNodes().size(),
-          v6Size);
+      log.debug("Tree {} node size:{}, v4 node size:{}, v6 node size:{}", entry.getKey(),
+          tree.getDnsNodes().size(), v4Size, v6Size);
       if (ipv6Nodes.size() > 0) {
         log.debug("Node with ipv6: {}", ipv6Nodes);
       }


### PR DESCRIPTION
What does this PR do?
1. Filter ip that has been used by channel when use dns nodes to establish tcp connections.
2. merge changes from develop
3. add more debug log in getDnsNodes
4. fix bug of Node's function toString() if its nodeis is empty

Why are these changes required?

This PR has been tested by:

Unit Tests
Manual Testing
Follow up

Extra details