### PR TITLE
fix(net): Use node change percent in AliClient as AwsClient

### DIFF
--- a/src/main/java/org/tron/p2p/dns/tree/Tree.java
+++ b/src/main/java/org/tron/p2p/dns/tree/Tree.java
@@ -16,6 +16,7 @@ import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.tron.p2p.dns.DnsNode;
+import org.tron.p2p.dns.update.AliClient;
 import org.tron.p2p.exception.DnsException;
 import org.tron.p2p.exception.DnsException.TypeEnum;
 import org.tron.p2p.utils.ByteArray;
@@ -153,7 +154,7 @@ public class Tree {
     if (StringUtils.isNoneEmpty(rootDomain)) {
       dnsRecords.put(rootDomain, rootEntry.toFormat());
     } else {
-      dnsRecords.put("@", rootEntry.toFormat());
+      dnsRecords.put(AliClient.aliyunRoot, rootEntry.toFormat());
     }
     for (Map.Entry<String, Entry> item : entries.entrySet()) {
       String hash = item.getKey();

--- a/src/main/java/org/tron/p2p/dns/update/AliClient.java
+++ b/src/main/java/org/tron/p2p/dns/update/AliClient.java
@@ -32,6 +32,7 @@ public class AliClient implements Publish {
   private Set<DnsNode> serverNodes;
   private final Client aliDnsClient;
   private double changeThreshold;
+  public static final String aliyunRoot = "@";
 
   public AliClient(String endpoint, String accessKeyId, String accessKeySecret,
       double changeThreshold) throws Exception {
@@ -119,7 +120,7 @@ public class AliClient implements Publish {
               .getDomainRecords().getRecord()) {
             String name = StringUtils.stripEnd(r.getRR(), ".");
             records.put(name, r);
-            if (domain.equalsIgnoreCase(name)) {
+            if (aliyunRoot.equalsIgnoreCase(name)) {
               rootContent = r.value;
             }
             if (StringUtils.isNotEmpty(r.value) && r.value.startsWith(

--- a/src/main/java/org/tron/p2p/dns/update/AliClient.java
+++ b/src/main/java/org/tron/p2p/dns/update/AliClient.java
@@ -78,12 +78,12 @@ public class AliClient implements Publish {
       } else {
         NumberFormat nf = NumberFormat.getNumberInstance();
         nf.setMaximumFractionDigits(4);
-        double changePercent = serverNodes.isEmpty() ? 1.0
-            : ((addNodeSize + deleteNodeSize) / (double) serverNodes.size());
+        double changePercent = (addNodeSize + deleteNodeSize) / (double) serverNodes.size();
         log.info(
             "Sum of node add & delete percent {} is below changeThreshold {}, skip this changes",
             nf.format(changePercent), changeThreshold);
       }
+      serverNodes.clear();
     } catch (Exception e) {
       throw new DnsException(DnsException.TypeEnum.DEPLOY_DOMAIN_FAILED, e);
     }

--- a/src/main/java/org/tron/p2p/dns/update/AliClient.java
+++ b/src/main/java/org/tron/p2p/dns/update/AliClient.java
@@ -4,9 +4,14 @@ import com.aliyun.alidns20150109.Client;
 import com.aliyun.alidns20150109.models.*;
 import com.aliyun.alidns20150109.models.DescribeDomainRecordsResponseBody.DescribeDomainRecordsResponseBodyDomainRecordsRecord;
 import com.aliyun.teaopenapi.models.Config;
+import java.text.NumberFormat;
+import java.util.HashSet;
+import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.tron.p2p.dns.DnsNode;
 import org.tron.p2p.dns.tree.LinkEntry;
+import org.tron.p2p.dns.tree.NodesEntry;
 import org.tron.p2p.dns.tree.RootEntry;
 import org.tron.p2p.dns.tree.Tree;
 import org.tron.p2p.exception.DnsException;
@@ -24,6 +29,7 @@ public class AliClient implements Publish {
   private final long retryWaitTime = 30;
   private final int treeNodeTTL = 24 * 60 * 60;
   private int lastSeq = 0;
+  private Set<DnsNode> serverNodes;
   private final Client aliDnsClient;
   private double changeThreshold;
 
@@ -34,6 +40,7 @@ public class AliClient implements Publish {
     config.accessKeySecret = accessKeySecret;
     config.endpoint = endpoint;
     this.changeThreshold = changeThreshold;
+    this.serverNodes = new HashSet<>();
     aliDnsClient = new Client(config);
   }
 
@@ -46,12 +53,37 @@ public class AliClient implements Publish {
     try {
       Map<String, DescribeDomainRecordsResponseBodyDomainRecordsRecord> existing = collectRecords(
           domainName);
+      log.info("Find {} TXT records, {} nodes for {}", existing.size(), serverNodes.size(),
+          domainName);
       String represent = LinkEntry.buildRepresent(t.getBase32PublicKey(), domainName);
       log.info("Trying to publish {}", represent);
       t.setSeq(this.lastSeq + 1);
       t.sign(); //seq changed, wo need to sign again
       Map<String, String> records = t.toTXT(null);
-      submitChanges(domainName, records, existing);
+
+      Set<DnsNode> treeNodes = new HashSet<>(t.getDnsNodes());
+      treeNodes.removeAll(serverNodes); // tree - dns
+      int addNodeSize = treeNodes.size();
+
+      Set<DnsNode> set1 = new HashSet<>(serverNodes);
+      treeNodes = new HashSet<>(t.getDnsNodes());
+      set1.removeAll(treeNodes); // dns - tree
+      int deleteNodeSize = set1.size();
+
+      if (serverNodes.isEmpty()
+          || (addNodeSize + deleteNodeSize) / (double) serverNodes.size() >= changeThreshold) {
+        String comment = String.format("Tree update of %s at seq %d", domainName, t.getSeq());
+        log.info(comment);
+        submitChanges(domainName, records, existing);
+      } else {
+        NumberFormat nf = NumberFormat.getNumberInstance();
+        nf.setMaximumFractionDigits(4);
+        double changePercent = serverNodes.isEmpty() ? 1.0
+            : ((addNodeSize + deleteNodeSize) / (double) serverNodes.size());
+        log.info(
+            "Sum of node add & delete percent {} is below changeThreshold {}, skip this changes",
+            nf.format(changePercent), changeThreshold);
+      }
     } catch (Exception e) {
       throw new DnsException(DnsException.TypeEnum.DEPLOY_DOMAIN_FAILED, e);
     }
@@ -72,6 +104,7 @@ public class AliClient implements Publish {
     Map<String, DescribeDomainRecordsResponseBodyDomainRecordsRecord> records = new HashMap<>();
 
     String rootContent = null;
+    Set<DnsNode> collectServerNodes = new HashSet<>();
     try {
       DescribeDomainRecordsRequest request = new DescribeDomainRecordsRequest();
       request.setDomainName(domain);
@@ -88,6 +121,18 @@ public class AliClient implements Publish {
             records.put(name, r);
             if (domain.equalsIgnoreCase(name)) {
               rootContent = r.value;
+            }
+            if (StringUtils.isNotEmpty(r.value) && r.value.startsWith(
+                org.tron.p2p.dns.tree.Entry.nodesPrefix)) {
+              NodesEntry nodesEntry;
+              try {
+                nodesEntry = NodesEntry.parseEntry(r.value);
+                List<DnsNode> dnsNodes = nodesEntry.getNodes();
+                collectServerNodes.addAll(dnsNodes);
+              } catch (DnsException e) {
+                //ignore
+                log.error("Parse nodeEntry failed: {}", e.getMessage());
+              }
             }
           }
           if (currentPageNum * domainRecordsPageSize >= response.getBody().getTotalCount()) {
@@ -107,7 +152,7 @@ public class AliClient implements Publish {
       RootEntry rootEntry = RootEntry.parseEntry(rootContent);
       this.lastSeq = rootEntry.getSeq();
     }
-
+    this.serverNodes = collectServerNodes;
     return records;
   }
 
@@ -115,9 +160,6 @@ public class AliClient implements Publish {
       Map<String, String> records,
       Map<String, DescribeDomainRecordsResponseBodyDomainRecordsRecord> existing)
       throws Exception {
-    if (!computeChanges(domainName, records, existing)) {
-      return;
-    }
     long ttl;
     long addCount = 0;
     long updateCount = 0;
@@ -149,44 +191,8 @@ public class AliClient implements Publish {
         deleteCount++;
       }
     }
-    log.debug("Published successfully, add count:{}, update count:{}, delete count:{}",
+    log.info("Published successfully, add count:{}, update count:{}, delete count:{}",
         addCount, updateCount, deleteCount);
-  }
-
-  private boolean computeChanges(String domainName,
-      Map<String, String> records,
-      Map<String, DescribeDomainRecordsResponseBodyDomainRecordsRecord> existing) {
-    long ttl;
-    long changeCount = 0;
-    for (Map.Entry<String, String> entry : records.entrySet()) {
-      ttl = treeNodeTTL;
-      if (entry.getKey().equals(domainName)) {
-        ttl = rootTTL;
-      }
-      if (!existing.containsKey(entry.getKey())) {
-        changeCount++;
-      } else if (!entry.getValue().equals(existing.get(entry.getKey()).getValue()) ||
-          existing.get(entry.getKey()).getTTL() != ttl) {
-        changeCount++;
-      }
-    }
-
-    for (String key : existing.keySet()) {
-      if (!records.containsKey(key)) {
-        changeCount++;
-      }
-    }
-
-    if (changeCount > 0
-        && (existing.size() == 0 || (double) changeCount / existing.size() > changeThreshold)) {
-      log.info("change count: {}, existing count: {}",
-          changeCount, existing.size());
-      return true;
-    } else {
-      log.info("The number of changed data is too small, change count: {}, existing count: {}",
-          changeCount, existing.size());
-      return false;
-    }
   }
 
   public boolean addRecord(String domainName, String RR, String value, long ttl) throws Exception {

--- a/src/main/java/org/tron/p2p/dns/update/AwsClient.java
+++ b/src/main/java/org/tron/p2p/dns/update/AwsClient.java
@@ -155,11 +155,11 @@ public class AwsClient implements Publish {
     } else {
       NumberFormat nf = NumberFormat.getNumberInstance();
       nf.setMaximumFractionDigits(4);
-      double changePercent = serverNodes.isEmpty() ? 1.0
-          : ((addNodeSize + deleteNodeSize) / (double) serverNodes.size());
+      double changePercent = (addNodeSize + deleteNodeSize) / (double) serverNodes.size();
       log.info("Sum of node add & delete percent {} is below changeThreshold {}, skip this changes",
           nf.format(changePercent), changeThreshold);
     }
+    serverNodes.clear();
   }
 
   // removes all TXT records of the given domain.

--- a/src/main/java/org/tron/p2p/dns/update/PublishService.java
+++ b/src/main/java/org/tron/p2p/dns/update/PublishService.java
@@ -37,7 +37,12 @@ public class PublishService {
         log.error("Init PublishService failed", e);
         return;
       }
-      publisher.scheduleWithFixedDelay(this::startPublish, 300, publishDelay, TimeUnit.SECONDS);
+
+      if (publishConfig.getStaticNodes() != null && !publishConfig.getStaticNodes().isEmpty()) {
+        startPublish();
+      } else {
+        publisher.scheduleWithFixedDelay(this::startPublish, 300, publishDelay, TimeUnit.SECONDS);
+      }
     }
   }
 
@@ -64,7 +69,7 @@ public class PublishService {
       Tree tree = new Tree();
       List<String> nodes = getNodes(config);
       tree.makeTree(1, nodes, config.getKnownTreeUrls(), config.getDnsPrivate());
-      log.debug("Try to publish node count:{}", tree.getDnsNodes().size());
+      log.info("Try to publish node count:{}", tree.getDnsNodes().size());
       publish.deploy(config.getDnsDomain(), tree);
     } catch (Exception e) {
       log.error("Failed to publish dns", e);


### PR DESCRIPTION
What does this PR do?

1. Use node change percent in AliClient as AwsClient
2. Publish dns only once if publish static nodes
3. fix the bug of seq not change in AliClient

Why are these changes required?

This PR has been tested by:

Unit Tests
Manual Testing
Follow up

Extra details