### PR TITLE
feature: optimize random disconnect

### DIFF
--- a/src/main/java/org/tron/p2p/P2pConfig.java
+++ b/src/main/java/org/tron/p2p/P2pConfig.java
@@ -28,7 +28,7 @@ public class P2pConfig {
   private boolean discoverEnable = true;
   private boolean disconnectionPolicyEnable = false;
   // only if peer is not active last more than this interval (milliseconds), peer might be disconnected randomly
-  private int notActiveInterval = 300_000;
+  private long notActiveInterval = 300_000L;
   private boolean nodeDetectEnable = false;
 
   //dns read config

--- a/src/main/java/org/tron/p2p/P2pConfig.java
+++ b/src/main/java/org/tron/p2p/P2pConfig.java
@@ -27,6 +27,8 @@ public class P2pConfig {
   private int maxConnectionsWithSameIp = 2;
   private boolean discoverEnable = true;
   private boolean disconnectionPolicyEnable = false;
+  // only if peer is not active last more than this interval (milliseconds), peer might be disconnected randomly
+  private int notActiveInterval = 300_000;
   private boolean nodeDetectEnable = false;
 
   //dns read config

--- a/src/main/java/org/tron/p2p/connection/Channel.java
+++ b/src/main/java/org/tron/p2p/connection/Channel.java
@@ -60,6 +60,9 @@ public class Channel {
   @Getter
   private final long startTime = System.currentTimeMillis();
   @Getter
+  @Setter
+  private long lastActiveTime = System.currentTimeMillis();
+  @Getter
   private boolean isActive = false;
   @Getter
   private boolean isTrustPeer;

--- a/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
+++ b/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
@@ -54,7 +54,6 @@ public class ConnPoolService extends P2pEventHandler {
       new BasicThreadFactory.Builder().namingPattern("connPool").build());
   private final ScheduledExecutorService disconnectExecutor = Executors.newSingleThreadScheduledExecutor(
       new BasicThreadFactory.Builder().namingPattern("randomDisconnect").build());
-  private static final int inActiveInterval = 300_000; //ms
 
   public P2pConfig p2pConfig = Parameter.p2pConfig;
   private PeerClient peerClient;
@@ -246,7 +245,8 @@ public class ConnPoolService extends P2pEventHandler {
         .filter(peer -> !peer.isDisconnect())
         .filter(peer -> !peer.isTrustPeer())
         .filter(peer -> !peer.isActive())
-        .filter(peer -> System.currentTimeMillis() - peer.getLastActiveTime() < inActiveInterval)
+        .filter(peer -> System.currentTimeMillis() - peer.getLastActiveTime()
+            > p2pConfig.getNotActiveInterval())
         .collect(Collectors.toList());
 
     // if len(peers) >= 0, disconnect randomly

--- a/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
+++ b/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
@@ -54,6 +54,7 @@ public class ConnPoolService extends P2pEventHandler {
       new BasicThreadFactory.Builder().namingPattern("connPool").build());
   private final ScheduledExecutorService disconnectExecutor = Executors.newSingleThreadScheduledExecutor(
       new BasicThreadFactory.Builder().namingPattern("randomDisconnect").build());
+  private static final int inActiveInterval = 300_000; //ms
 
   public P2pConfig p2pConfig = Parameter.p2pConfig;
   private PeerClient peerClient;
@@ -245,6 +246,7 @@ public class ConnPoolService extends P2pEventHandler {
         .filter(peer -> !peer.isDisconnect())
         .filter(peer -> !peer.isTrustPeer())
         .filter(peer -> !peer.isActive())
+        .filter(peer -> System.currentTimeMillis() - peer.getLastActiveTime() < inActiveInterval)
         .collect(Collectors.toList());
 
     // if len(peers) >= 0, disconnect randomly


### PR DESCRIPTION
**What does this PR do?**

In the stratrgy of random disconnection, we will not disconnect from nodes that were active in the last notActiveInterval minutes. Parameter notActiveInterval can be configured by command line, default 5 minutes.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**

