### PR TITLE
feat(net): Don't sumbit new task when connection pool's queue size is too large

### DIFF
--- a/src/main/java/org/tron/p2p/base/Parameter.java
+++ b/src/main/java/org/tron/p2p/base/Parameter.java
@@ -24,6 +24,8 @@ public class Parameter {
 
   public static final int UDP_NETTY_WORK_THREAD_NUM = 1;
 
+  public static final int CONN_POOL_SIZE = 10;
+
   public static final int NODE_CONNECTION_TIMEOUT = 2000;
 
   public static final int KEEP_ALIVE_TIMEOUT = 20_000;

--- a/src/main/java/org/tron/p2p/base/Parameter.java
+++ b/src/main/java/org/tron/p2p/base/Parameter.java
@@ -24,7 +24,7 @@ public class Parameter {
 
   public static final int UDP_NETTY_WORK_THREAD_NUM = 1;
 
-  public static final int CONN_POOL_SIZE = 10;
+  public static final int CONN_MAX_QUEUE_SIZE = 10;
 
   public static final int NODE_CONNECTION_TIMEOUT = 2000;
 

--- a/src/main/java/org/tron/p2p/connection/business/detect/NodeDetectService.java
+++ b/src/main/java/org/tron/p2p/connection/business/detect/NodeDetectService.java
@@ -36,7 +36,7 @@ public class NodeDetectService implements MessageProcess {
       .newBuilder().maximumSize(5000).expireAfterWrite(1, TimeUnit.HOURS).build();
 
   private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
-      new BasicThreadFactory.Builder().namingPattern("nodeDetectService").build());
+      BasicThreadFactory.builder().namingPattern("nodeDetectService").build());
 
   private final long NODE_DETECT_THRESHOLD = 5 * 60 * 1000;
 

--- a/src/main/java/org/tron/p2p/connection/business/keepalive/KeepAliveService.java
+++ b/src/main/java/org/tron/p2p/connection/business/keepalive/KeepAliveService.java
@@ -21,7 +21,7 @@ import org.tron.p2p.protos.Connect.DisconnectReason;
 public class KeepAliveService implements MessageProcess {
 
   private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
-      new BasicThreadFactory.Builder().namingPattern("keepAlive").build());
+      BasicThreadFactory.builder().namingPattern("keepAlive").build());
 
   public void init() {
     executor.scheduleWithFixedDelay(() -> {

--- a/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
+++ b/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
@@ -271,8 +271,8 @@ public class ConnPoolService extends P2pEventHandler {
       return;
     }
     connectingPeersCount.decrementAndGet();
-    if (poolLoopExecutor.getQueue().size() > Parameter.CONN_POOL_SIZE) {
-      log.warn("ConnPool task' size is bigger than {}", Parameter.CONN_POOL_SIZE);
+    if (poolLoopExecutor.getQueue().size() > Parameter.CONN_MAX_QUEUE_SIZE) {
+      log.warn("ConnPool task' size is bigger than {}", Parameter.CONN_MAX_QUEUE_SIZE);
       return;
     }
     try {

--- a/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
+++ b/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
@@ -271,8 +271,8 @@ public class ConnPoolService extends P2pEventHandler {
       return;
     }
     connectingPeersCount.decrementAndGet();
-    if (poolLoopExecutor.getQueue().size() > Parameter.CONN_MAX_QUEUE_SIZE) {
-      log.warn("ConnPool task' size is bigger than {}", Parameter.CONN_MAX_QUEUE_SIZE);
+    if (poolLoopExecutor.getQueue().size() >= Parameter.CONN_MAX_QUEUE_SIZE) {
+      log.warn("ConnPool task' size is greater than or equal to {}", Parameter.CONN_MAX_QUEUE_SIZE);
       return;
     }
     try {

--- a/src/main/java/org/tron/p2p/connection/socket/PeerClient.java
+++ b/src/main/java/org/tron/p2p/connection/socket/PeerClient.java
@@ -23,7 +23,7 @@ public class PeerClient {
 
   public void init() {
     workerGroup = new NioEventLoopGroup(0,
-        new BasicThreadFactory.Builder().namingPattern("peerClient-%d").build());
+        BasicThreadFactory.builder().namingPattern("peerClient-%d").build());
   }
 
   public void close() {

--- a/src/main/java/org/tron/p2p/connection/socket/PeerServer.java
+++ b/src/main/java/org/tron/p2p/connection/socket/PeerServer.java
@@ -39,10 +39,10 @@ public class PeerServer {
 
   public void start(int port) {
     EventLoopGroup bossGroup = new NioEventLoopGroup(1,
-        new BasicThreadFactory.Builder().namingPattern("peerBoss").build());
+        BasicThreadFactory.builder().namingPattern("peerBoss").build());
     //if threads = 0, it is number of core * 2
     EventLoopGroup workerGroup = new NioEventLoopGroup(Parameter.TCP_NETTY_WORK_THREAD_NUM,
-        new BasicThreadFactory.Builder().namingPattern("peerWorker-%d").build());
+        BasicThreadFactory.builder().namingPattern("peerWorker-%d").build());
     P2pChannelInitializer p2pChannelInitializer = new P2pChannelInitializer("", false, true);
     try {
       ServerBootstrap b = new ServerBootstrap();

--- a/src/main/java/org/tron/p2p/discover/Node.java
+++ b/src/main/java/org/tron/p2p/discover/Node.java
@@ -16,6 +16,8 @@ public class Node implements Serializable, Cloneable {
 
   private static final long serialVersionUID = -4267600517925770636L;
 
+  @Setter
+  @Getter
   private byte[] id;
 
   @Getter
@@ -24,6 +26,8 @@ public class Node implements Serializable, Cloneable {
   @Getter
   protected String hostV6;
 
+  @Setter
+  @Getter
   protected int port;
 
   @Setter
@@ -32,6 +36,7 @@ public class Node implements Serializable, Cloneable {
   @Setter
   private int p2pVersion;
 
+  @Getter
   private long updateTime;
 
   public Node(InetSocketAddress address) {
@@ -111,24 +116,8 @@ public class Node implements Serializable, Cloneable {
     return getIdShort(getHexId());
   }
 
-  public byte[] getId() {
-    return id;
-  }
-
-  public void setId(byte[] id) {
-    this.id = id;
-  }
-
   public String getHostKey() {
     return getPreferInetSocketAddress().getAddress().getHostAddress();
-  }
-
-  public int getPort() {
-    return port;
-  }
-
-  public void setPort(int port) {
-    this.port = port;
   }
 
   public String getIdString() {
@@ -136,10 +125,6 @@ public class Node implements Serializable, Cloneable {
       return null;
     }
     return new String(id);
-  }
-
-  public long getUpdateTime() {
-    return updateTime;
   }
 
   public void touch() {
@@ -179,8 +164,8 @@ public class Node implements Serializable, Cloneable {
     return false;
   }
 
-  private String getIdShort(String Id) {
-    return Id == null ? "<null>" : Id.substring(0, 8);
+  private String getIdShort(String hexId) {
+    return hexId == null ? "<null>" : hexId.substring(0, 8);
   }
 
   public InetSocketAddress getInetSocketAddressV4() {

--- a/src/main/java/org/tron/p2p/discover/protocol/kad/DiscoverTask.java
+++ b/src/main/java/org/tron/p2p/discover/protocol/kad/DiscoverTask.java
@@ -15,7 +15,7 @@ import org.tron.p2p.utils.NetUtil;
 public class DiscoverTask {
 
   private ScheduledExecutorService discoverer = Executors.newSingleThreadScheduledExecutor(
-      new BasicThreadFactory.Builder().namingPattern("discoverTask").build());
+      BasicThreadFactory.builder().namingPattern("discoverTask").build());
 
   private KadService kadService;
 

--- a/src/main/java/org/tron/p2p/discover/protocol/kad/KadService.java
+++ b/src/main/java/org/tron/p2p/discover/protocol/kad/KadService.java
@@ -57,7 +57,7 @@ public class KadService implements DiscoverService {
       bootNodes.add(new Node(address));
     }
     this.pongTimer = Executors.newSingleThreadScheduledExecutor(
-        new BasicThreadFactory.Builder().namingPattern("pongTimer").build());
+        BasicThreadFactory.builder().namingPattern("pongTimer").build());
     this.homeNode = new Node(Parameter.p2pConfig.getNodeID(), Parameter.p2pConfig.getIp(),
         Parameter.p2pConfig.getIpv6(), Parameter.p2pConfig.getPort());
     this.table = new NodeTable(homeNode);

--- a/src/main/java/org/tron/p2p/dns/sync/Client.java
+++ b/src/main/java/org/tron/p2p/dns/sync/Client.java
@@ -10,7 +10,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
@@ -42,7 +41,7 @@ public class Client {
   private final Map<String, ClientTree> clientTrees = new HashMap<>();
 
   private final ScheduledExecutorService syncer = Executors.newSingleThreadScheduledExecutor(
-      new BasicThreadFactory.Builder().namingPattern("dnsSyncer").build());
+      BasicThreadFactory.builder().namingPattern("dnsSyncer").build());
 
   public Client() {
     this.cache = CacheBuilder.newBuilder()

--- a/src/main/java/org/tron/p2p/dns/update/PublishService.java
+++ b/src/main/java/org/tron/p2p/dns/update/PublishService.java
@@ -25,7 +25,7 @@ public class PublishService {
   private static final long publishDelay = 1 * 60 * 60;
 
   private ScheduledExecutorService publisher = Executors.newSingleThreadScheduledExecutor(
-      new BasicThreadFactory.Builder().namingPattern("publishService").build());
+      BasicThreadFactory.builder().namingPattern("publishService").build());
   private Publish publish;
 
   public void init() {

--- a/src/main/java/org/tron/p2p/utils/NetUtil.java
+++ b/src/main/java/org/tron/p2p/utils/NetUtil.java
@@ -214,7 +214,7 @@ public class NetUtil {
 
   private static String getIp(List<String> multiSrcUrls) {
     ExecutorService executor = Executors.newCachedThreadPool(
-        new BasicThreadFactory.Builder().namingPattern("getIp").build());
+        BasicThreadFactory.builder().namingPattern("getIp").build());
     CompletionService<String> completionService = new ExecutorCompletionService<>(executor);
 
     List<Callable<String>> tasks = new ArrayList<>();


### PR DESCRIPTION
**What does this PR do?**

- change `poolLoopExecutor` from newSingleThreadScheduledExecutor to ScheduledThreadPoolExecutor with corePoolSize 1
- Don't sumbit new task when `poolLoopExecutor` queue size is too large, avoid OOM in some abnormal cases.
- use `BasicThreadFactory.builder()` to replace deprecated `new BasicThreadFactory.Builder()`.
- add @Setter,@Getter to simply class `Node`.
- shutdown disconnectExecutor when `ConnPoolService` close.

**Why are these changes required?**

I encounter 16GB OOM when running FullNode with libp2p, it happens when  the Network outage of Cloud server occurs for several days.  MemoryAnalyze's result is following:

![telegram-cloud-photo-size-5-6255860973659341330-y](https://github.com/user-attachments/assets/bb6708a2-a806-4012-99d9-6ba5537640ec)

![telegram-cloud-photo-size-5-6255860973659341338-y](https://github.com/user-attachments/assets/09cf2ed5-7f47-4d5f-9de1-4b489aac116a)

Look at the small object:
![telegram-cloud-photo-size-5-6296317899144104896-y](https://github.com/user-attachments/assets/5ef6c2ad-ea76-4eb2-a496-d0d5c6becec5)

And the log sample is this:
![telegram-cloud-photo-size-5-6255788049409623603-y](https://github.com/user-attachments/assets/446bb8f8-0c27-45fc-9968-b2d54b16c494)

Restrict the connPool task size, So when this pool is large, the triggerConnect can not sumbit the new task.

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**