### PR TITLE
hotfix(net): fix the bug of completionService used in getIp

### DIFF
--- a/src/main/java/org/tron/p2p/utils/NetUtil.java
+++ b/src/main/java/org/tron/p2p/utils/NetUtil.java
@@ -93,6 +93,8 @@ public class NetUtil {
     String ip = null;
     try {
       URLConnection urlConnection = new URL(url).openConnection();
+      urlConnection.setConnectTimeout(30_000); //ms
+      urlConnection.setReadTimeout(30_000); //ms
       in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()));
       ip = in.readLine();
       if (ip == null || ip.trim().isEmpty()) {

--- a/src/main/java/org/tron/p2p/utils/NetUtil.java
+++ b/src/main/java/org/tron/p2p/utils/NetUtil.java
@@ -215,7 +215,7 @@ public class NetUtil {
   private static String getIp(List<String> multiSrcUrls, boolean isAskIpv4) {
     int threadSize = multiSrcUrls.size();
     ExecutorService executor = Executors.newFixedThreadPool(threadSize,
-        BasicThreadFactory.builder().namingPattern("getIp").build());
+        BasicThreadFactory.builder().namingPattern("getIp-%d").build());
     CompletionService<String> completionService = new ExecutorCompletionService<>(executor);
 
     for (String url : multiSrcUrls) {

--- a/src/test/java/org/tron/p2p/utils/NetUtilTest.java
+++ b/src/test/java/org/tron/p2p/utils/NetUtilTest.java
@@ -1,14 +1,12 @@
 package org.tron.p2p.utils;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.InetSocketAddress;
 import org.junit.Assert;
 import org.junit.Test;
 import org.tron.p2p.base.Constant;
 import org.tron.p2p.discover.Node;
 import org.tron.p2p.protos.Discover;
-
-import java.net.InetSocketAddress;
 
 public class NetUtilTest {
 
@@ -83,11 +81,11 @@ public class NetUtilTest {
     //notice: please check that you only have one externalIP
     String ip1 = null, ip2 = null, ip3 = null;
     try {
-      Method method = NetUtil.class.getDeclaredMethod("getExternalIp", String.class);
+      Method method = NetUtil.class.getDeclaredMethod("getExternalIp", String.class, boolean.class);
       method.setAccessible(true);
-      ip1 = (String) method.invoke(NetUtil.class, Constant.ipV4Urls.get(0));
-      ip2 = (String) method.invoke(NetUtil.class, Constant.ipV4Urls.get(1));
-      ip3 = (String) method.invoke(NetUtil.class, Constant.ipV4Urls.get(2));
+      ip1 = (String) method.invoke(NetUtil.class, Constant.ipV4Urls.get(0), true);
+      ip2 = (String) method.invoke(NetUtil.class, Constant.ipV4Urls.get(1), true);
+      ip3 = (String) method.invoke(NetUtil.class, Constant.ipV4Urls.get(2), true);
     } catch (Exception e) {
       Assert.fail();
     }


### PR DESCRIPTION
**What does this PR do?**

- fix the bug of CompletionService. Only when the result is valid, we stop the thread pool.
- check the result of `getIp` before return.

**Why are these changes required?**

**This PR has been tested by:**
- Unit Tests
- Manual Testing

**Follow up**

**Extra details**