### PR TITLE
fix(net): reject non-literal hostV6 to avoid blocking DNS lookup on I/O thread

### DIFF
--- a/src/main/java/org/tron/p2p/discover/Node.java
+++ b/src/main/java/org/tron/p2p/discover/Node.java
@@ -89,6 +89,12 @@ public class Node implements Serializable, Cloneable {
   //use standard ipv6 format
   private void formatHostV6() {
     if (StringUtils.isNotEmpty(this.hostV6)) {
+      // Only canonicalize valid IPv6 literals. a non-literal triggers a blocking JVM DNS lookup
+      // on the calling (netty I/O) thread
+      if (!NetUtil.validIpV6(this.hostV6)) {
+        this.hostV6 = null;
+        return;
+      }
       this.hostV6 = new InetSocketAddress(hostV6, port).getAddress().getHostAddress();
     }
   }

--- a/src/test/java/org/tron/p2p/discover/NodeTest.java
+++ b/src/test/java/org/tron/p2p/discover/NodeTest.java
@@ -38,6 +38,15 @@ public class NodeTest {
   }
 
   @Test
+  public void hostV6NonLiteralRejectedWithoutDnsTest() {
+    // A non-literal hostV6 (e.g. an attacker-supplied domain) must be rejected by formatHostV6
+    // without performing a blocking DNS lookup. Guard against the I/O-thread DoS regression.
+    Node node = new Node(NetUtil.getNodeId(), null,
+        "rnd-" + System.nanoTime() + ".attacker-zone.invalid", 10002);
+    Assert.assertNull(node.getHostV6());
+  }
+
+  @Test
   public void ipV4CompatibleTest() {
     Parameter.p2pConfig.setIp("127.0.0.1");
     Parameter.p2pConfig.setIpv6(null);


### PR DESCRIPTION
## What

Guard `Node.formatHostV6()` so it only canonicalizes valid IPv6 **literals**. A non-literal `hostV6` (i.e. a hostname/domain) is now rejected up front (`hostV6` set to `null`) instead of being passed into `new InetSocketAddress(String, int)`.

## Why

`formatHostV6()` is invoked from every `Node` constructor:

```java
this.hostV6 = new InetSocketAddress(hostV6, port).getAddress().getHostAddress();
```

`new InetSocketAddress(String, int)` performs a **synchronous, blocking JVM DNS resolution** whenever the string is not an IP literal. The `hostV6` value is fully attacker-controlled and reaches this code with no prior validation: `NetUtil.getNode(endpoint)` converts the `addressIpv6` protobuf bytes straight into a string and feeds it to the constructor.

This is reachable on the UDP discovery path without any authentication or handshake:

```
P2pPacketDecoder.decode()            [netty UDP I/O thread]
  └─ Message.parse()
       └─ message.valid()            → NetUtil.validNode(getFrom())
            └─ getFrom()             → NetUtil.getNode(...) → new Node(...)
                 └─ formatHostV6()   → blocking DNS lookup
```

Because UDP discovery runs on a **single worker thread** (`UDP_NETTY_WORK_THREAD_NUM = 1`) and there is no per-source rate limiting, an attacker can send unauthenticated, source-spoofable `KAD_PING` packets whose `addressIpv6` field is a domain pointing at a blackhole zone (no NS response). Each packet stalls the discovery thread for the resolver timeout (seconds). Using a fresh random subdomain per packet defeats the JVM negative DNS cache, so every packet incurs a fresh blocking lookup — serializing/stalling the entire discovery subsystem. On resolution failure `getAddress()` returns `null`, and the subsequent `.getHostAddress()` throws an NPE (swallowed downstream).

The existing `validIpV6` check inside `NetUtil.validNode()` cannot prevent this: it runs against an already-constructed `Node`, by which time `formatHostV6()` has already performed the DNS lookup. The fix must live in `formatHostV6()` itself.

## How

- `formatHostV6()` calls `NetUtil.validIpV6()` before resolving. Non-literals are dropped (`hostV6 = null`) and never touch `InetSocketAddress`. Valid literals are parsed locally with no network I/O, so canonicalization behavior is unchanged.
- Added `NodeTest.hostV6NonLiteralRejectedWithoutDnsTest` as a regression test: a domain-like `hostV6` must yield `null` without a blocking lookup.

## Severity

Medium (low end) — unauthenticated, source-spoofable availability DoS limited to the discovery subsystem. It does not crash the node, cause OOM, or affect consensus/funds.

## Test

`./gradlew test --tests "org.tron.p2p.discover.NodeTest"` — all pass, including the new regression test.
