### PR TITLE
fix: bound HelloMessage toString output size

### DIFF
--- a/src/main/java/org/tron/p2p/connection/message/handshake/HelloMessage.java
+++ b/src/main/java/org/tron/p2p/connection/message/handshake/HelloMessage.java
@@ -7,7 +7,6 @@ import org.tron.p2p.connection.message.MessageType;
 import org.tron.p2p.discover.Node;
 import org.tron.p2p.protos.Connect;
 import org.tron.p2p.protos.Discover;
-import org.tron.p2p.utils.ByteArray;
 import org.tron.p2p.utils.NetUtil;
 
 public class HelloMessage extends Message {
@@ -53,25 +52,13 @@ public class HelloMessage extends Message {
 
   @Override
   public String toString() {
-    return "[HelloMessage: " + format();
+    return "HelloMessage networkId: " + getNetworkId() +
+            ", version: " + getVersion() +
+            ", code: " + getCode();
   }
 
   @Override
   public boolean valid() {
     return NetUtil.validNode(getFrom());
   }
-
-  public String format() {
-    String[] lines = helloMessage.toString().split("\n");
-    StringBuilder sb = new StringBuilder();
-    for (String line : lines) {
-      if (line.contains("nodeId")) {
-        String nodeId = ByteArray.toHexString(helloMessage.getFrom().getNodeId().toByteArray());
-        line = "  nodeId: \"" + nodeId + "\"";
-      }
-      sb.append(line).append("\n");
-    }
-    return sb.toString();
-  }
-
 }


### PR DESCRIPTION
Rewrite HelloMessage.toString to print only the bounded scalar fields (networkId, version, code) instead of the full protobuf TextFormat via format(), which printed unknown fields and escaped byte fields (1 byte -> up to 4 chars), letting a peer amplify a small Hello message into a large log string. Remove the now-unused format() method and the ByteArray import.