### PR TITLE
fix(tcp): don't handle application message before finish handshake

### DIFF
--- a/src/main/java/org/tron/p2p/connection/ChannelManager.java
+++ b/src/main/java/org/tron/p2p/connection/ChannelManager.java
@@ -110,6 +110,19 @@ public class ChannelManager {
   }
 
   public static synchronized DisconnectCode processPeer(Channel channel) {
+    DisconnectCode code = checkPeer(channel);
+    if (code != DisconnectCode.NORMAL) {
+      return code;
+    }
+    addPeer(channel);
+    return DisconnectCode.NORMAL;
+  }
+
+  /**
+   * Checks peer admission. Callers must hold the ChannelManager class lock until addPeer
+   * to prevent another connection from taking the checked capacity.
+   */
+  public static synchronized DisconnectCode checkPeer(Channel channel) {
 
     if (!channel.isActive() && !channel.isTrustPeer()) {
       InetAddress inetAddress = channel.getInetAddress();
@@ -132,6 +145,10 @@ public class ChannelManager {
     }
 
     if (StringUtils.isNotEmpty(channel.getNodeId())) {
+      if (channel.getNodeId().equals(Hex.toHexString(Parameter.p2pConfig.getNodeID()))) {
+        log.info("Channel {} is myself", channel.getInetSocketAddress());
+        return DisconnectCode.DUPLICATE_PEER;
+      }
       for (Channel c : channels.values()) {
         if (channel.getNodeId().equals(c.getNodeId())) {
           if (c.getStartTime() > channel.getStartTime()) {
@@ -144,10 +161,13 @@ public class ChannelManager {
       }
     }
 
+    return DisconnectCode.NORMAL;
+  }
+
+  public static synchronized void addPeer(Channel channel) {
     channels.put(channel.getInetSocketAddress(), channel);
 
     log.info("Add peer {}, total channels: {}", channel.getInetSocketAddress(), channels.size());
-    return DisconnectCode.NORMAL;
   }
 
   public static DisconnectReason getDisconnectReason(DisconnectCode code) {
@@ -255,15 +275,11 @@ public class ChannelManager {
     }
 
     if (!channel.isFinishHandshake()) {
-      channel.setFinishHandshake(true);
-      DisconnectCode code = processPeer(channel);
-      if (!DisconnectCode.NORMAL.equals(code)) {
-        DisconnectReason disconnectReason = getDisconnectReason(code);
-        channel.send(new P2pDisconnectMessage(disconnectReason));
-        channel.getCtx().close();
-        return;
-      }
-      Parameter.handlerList.forEach(h -> h.onConnect(channel));
+      log.warn("Close channel {}, application message received before handshake",
+          channel.getInetSocketAddress());
+      channel.send(new P2pDisconnectMessage(DisconnectReason.BAD_PROTOCOL));
+      channel.close();
+      return;
     }
 
     handler.onMessage(channel, data);

--- a/src/main/java/org/tron/p2p/connection/business/handshake/HandshakeService.java
+++ b/src/main/java/org/tron/p2p/connection/business/handshake/HandshakeService.java
@@ -24,6 +24,9 @@ public class HandshakeService implements MessageProcess {
 
   @Override
   public void processMessage(Channel channel, Message message) {
+    if (channel.isDisconnect()) {
+      return;
+    }
     HelloMessage msg = (HelloMessage) message;
 
     if (channel.isFinishHandshake()) {
@@ -33,9 +36,29 @@ public class HandshakeService implements MessageProcess {
       return;
     }
 
-    channel.setHelloMessage(msg);
+    if (msg.getNetworkId() != networkId) {
+      log.info("Peer {} different network id, peer->{}, me->{}",
+          channel.getInetSocketAddress(), msg.getNetworkId(), networkId);
+      if (!channel.isActive()) {
+        sendHelloMsg(channel, DisconnectCode.DIFFERENT_VERSION, msg.getTimestamp());
+      }
+      logDisconnectReason(channel, DisconnectReason.DIFFERENT_VERSION);
+      channel.close();
+      return;
+    }
 
-    DisconnectCode code = ChannelManager.processPeer(channel);
+    if (channel.isActive() && msg.getCode() != DisconnectCode.NORMAL.getValue()) {
+      DisconnectCode disconnectCode = DisconnectCode.forNumber(msg.getCode());
+      log.info("Handshake failed {}, code: {}, reason: {}, networkId: {}, version: {}",
+          channel.getInetSocketAddress(), msg.getCode(), disconnectCode.name(),
+          msg.getNetworkId(), msg.getVersion());
+      logDisconnectReason(channel, getDisconnectReason(disconnectCode));
+      channel.close();
+      return;
+    }
+
+    channel.setHelloMessage(msg);
+    DisconnectCode code = finishHandshake(channel, msg);
     if (code != DisconnectCode.NORMAL) {
       if (!channel.isActive()) {
         sendHelloMsg(channel, code, msg.getTimestamp());
@@ -44,42 +67,28 @@ public class HandshakeService implements MessageProcess {
       channel.close();
       return;
     }
-
-    ChannelManager.updateNodeId(channel, msg.getFrom().getHexId());
-    if (channel.isDisconnect()) {
-      return;
-    }
-
-    if (channel.isActive()) {
-      if (msg.getCode() != DisconnectCode.NORMAL.getValue()
-          || (msg.getNetworkId() != networkId && msg.getVersion() != networkId)) {
-        DisconnectCode disconnectCode = DisconnectCode.forNumber(msg.getCode());
-        //v0.1 have version, v0.2 both have version and networkId
-        log.info("Handshake failed {}, code: {}, reason: {}, networkId: {}, version: {}",
-            channel.getInetSocketAddress(),
-            msg.getCode(),
-            disconnectCode.name(),
-            msg.getNetworkId(),
-            msg.getVersion());
-        logDisconnectReason(channel, getDisconnectReason(disconnectCode));
-        channel.close();
-        return;
-      }
-    } else {
-
-      if (msg.getNetworkId() != networkId) {
-        log.info("Peer {} different network id, peer->{}, me->{}",
-            channel.getInetSocketAddress(), msg.getNetworkId(), networkId);
-        sendHelloMsg(channel, DisconnectCode.DIFFERENT_VERSION, msg.getTimestamp());
-        logDisconnectReason(channel, DisconnectReason.DIFFERENT_VERSION);
-        channel.close();
-        return;
-      }
-      sendHelloMsg(channel, DisconnectCode.NORMAL, msg.getTimestamp());
-    }
-    channel.setFinishHandshake(true);
-    channel.updateAvgLatency(System.currentTimeMillis() - channel.getStartTime());
     Parameter.handlerList.forEach(h -> h.onConnect(channel));
+  }
+
+  private DisconnectCode finishHandshake(Channel channel, HelloMessage msg) {
+    // Keep admission checks, handshake completion and registration in one critical section.
+    synchronized (ChannelManager.class) {
+      DisconnectCode code = ChannelManager.checkPeer(channel);
+      if (code != DisconnectCode.NORMAL) {
+        return code;
+      }
+      if (!channel.isActive()) {
+        // Hello must be sent before enabling the negotiated message compression.
+        sendHelloMsg(channel, DisconnectCode.NORMAL, msg.getTimestamp());
+      }
+      if (channel.isDisconnect() || !channel.getCtx().channel().isOpen()) {
+        return DisconnectCode.UNKNOWN;
+      }
+      channel.setFinishHandshake(true);
+      channel.updateAvgLatency(System.currentTimeMillis() - channel.getStartTime());
+      ChannelManager.addPeer(channel);
+      return DisconnectCode.NORMAL;
+    }
   }
 
   private void sendHelloMsg(Channel channel, DisconnectCode code, long time) {

--- a/src/test/java/org/tron/p2p/connection/HandshakeAdmissionTest.java
+++ b/src/test/java/org/tron/p2p/connection/HandshakeAdmissionTest.java
@@ -1,0 +1,411 @@
+package org.tron.p2p.connection;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.CodedInputStream;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.lang.reflect.Field;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tron.p2p.P2pConfig;
+import org.tron.p2p.P2pEventHandler;
+import org.tron.p2p.base.Parameter;
+import org.tron.p2p.connection.business.handshake.DisconnectCode;
+import org.tron.p2p.connection.business.handshake.HandshakeService;
+import org.tron.p2p.connection.business.upgrade.UpgradeController;
+import org.tron.p2p.connection.message.Message;
+import org.tron.p2p.connection.message.MessageType;
+import org.tron.p2p.connection.message.handshake.HelloMessage;
+import org.tron.p2p.protos.Connect;
+import org.tron.p2p.protos.Connect.DisconnectReason;
+import org.tron.p2p.protos.Discover;
+
+public class HandshakeAdmissionTest {
+
+  private static final int NETWORK_ID = 11111;
+  private static final byte[] APPLICATION_MESSAGE = {1, 2, 3};
+  private static P2pConfig config;
+
+  private P2pConfig previousConfig;
+  private int previousVersion;
+  private List<P2pEventHandler> previousHandlers;
+  private Map<Byte, P2pEventHandler> previousHandlerMap;
+  private Map<InetSocketAddress, Channel> previousChannels;
+  private Map<InetAddress, Long> previousBans;
+  private HandshakeService previousHandshakeService;
+  private final List<EmbeddedChannel> sockets = new ArrayList<>();
+  private final List<String> events = new ArrayList<>();
+
+  @BeforeClass
+  public static void createConfig() {
+    config = new P2pConfig();
+    config.setNetworkId(NETWORK_ID);
+    config.setNodeID(new byte[64]);
+    config.setIp("127.0.0.1");
+    config.setIpv6("");
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    previousConfig = Parameter.p2pConfig;
+    previousVersion = Parameter.version;
+    previousHandlers = Parameter.handlerList;
+    previousHandlerMap = Parameter.handlerMap;
+    previousChannels = new HashMap<>(ChannelManager.getChannels());
+    previousBans = new HashMap<>(ChannelManager.getBannedNodes().asMap());
+    previousHandshakeService = ChannelManager.getHandshakeService();
+    Parameter.p2pConfig = config;
+    Parameter.version = 1;
+    config.setMaxConnections(50);
+    config.setMaxConnectionsWithSameIp(2);
+    config.getTrustNodes().clear();
+    ChannelManager.getChannels().clear();
+    ChannelManager.getBannedNodes().invalidateAll();
+    Parameter.handlerList = new ArrayList<>();
+    Parameter.handlerMap = new HashMap<>();
+    P2pEventHandler handler = new P2pEventHandler() {
+      @Override
+      public void onConnect(Channel channel) {
+        Assert.assertTrue(channel.isFinishHandshake());
+        Assert.assertEquals(NETWORK_ID, channel.getHelloMessage().getNetworkId());
+        Assert.assertSame(channel,
+            ChannelManager.getChannels().get(channel.getInetSocketAddress()));
+        events.add("connect");
+      }
+
+      @Override
+      public void onMessage(Channel channel, byte[] data) {
+        Assert.assertArrayEquals(APPLICATION_MESSAGE, data);
+        events.add("message");
+      }
+    };
+    Parameter.handlerList.add(handler);
+    Parameter.handlerMap.put(APPLICATION_MESSAGE[0], handler);
+    setHandshakeService(new HandshakeService());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    try {
+      for (EmbeddedChannel socket : sockets) {
+        socket.finishAndReleaseAll();
+      }
+    } finally {
+      Parameter.p2pConfig = previousConfig;
+      Parameter.version = previousVersion;
+      Parameter.handlerList = previousHandlers;
+      Parameter.handlerMap = previousHandlerMap;
+      ChannelManager.getChannels().clear();
+      ChannelManager.getChannels().putAll(previousChannels);
+      ChannelManager.getBannedNodes().invalidateAll();
+      ChannelManager.getBannedNodes().putAll(previousBans);
+      setHandshakeService(previousHandshakeService);
+    }
+  }
+
+  @Test
+  public void applicationMessageBeforeHelloIsRejected() throws Exception {
+    TestChannel channel = newChannel(false, 10001);
+    receive(channel, APPLICATION_MESSAGE);
+
+    assertRejected(channel);
+    Assert.assertNull(channel.getHelloMessage());
+    Message reply = Message.parse(readOutbound(channel));
+    Assert.assertEquals(MessageType.DISCONNECT, reply.getType());
+    Assert.assertEquals(DisconnectReason.BAD_PROTOCOL,
+        Connect.P2pDisconnectMessage.parseFrom(reply.getData()).getReason());
+  }
+
+  @Test
+  public void outboundApplicationMessageBeforeHelloIsRejected() throws Exception {
+    TestChannel channel = newChannel(true, 10001);
+    receive(channel, APPLICATION_MESSAGE);
+
+    assertRejected(channel);
+  }
+
+  @Test
+  public void trustedPeerStillNeedsHello() throws Exception {
+    config.getTrustNodes().add(InetAddress.getByName("127.0.0.1"));
+    TestChannel channel = newChannel(false, 10001);
+    Assert.assertTrue(channel.isTrustPeer());
+    receive(channel, APPLICATION_MESSAGE);
+
+    assertRejected(channel);
+  }
+
+  @Test
+  public void inboundWrongNetworkIsNeverRegistered() throws Exception {
+    TestChannel channel = newChannel(false, 10001);
+    receive(channel, hello(NETWORK_ID + 1, 1, DisconnectCode.NORMAL, 1));
+
+    assertRejected(channel);
+    Assert.assertNull(channel.getHelloMessage());
+    HelloMessage reply = (HelloMessage) Message.parse(readOutbound(channel));
+    Assert.assertEquals(DisconnectCode.DIFFERENT_VERSION.getValue().intValue(), reply.getCode());
+  }
+
+  @Test
+  public void outboundWrongNetworkIsNeverRegistered() throws Exception {
+    TestChannel channel = newChannel(true, 10001);
+    receive(channel, hello(NETWORK_ID + 1, 1, DisconnectCode.NORMAL, 1));
+
+    assertRejected(channel);
+  }
+
+  @Test
+  public void protocolVersionCannotSubstituteForNetworkId() throws Exception {
+    TestChannel channel = newChannel(true, 10001);
+    receive(channel, hello(NETWORK_ID + 1, NETWORK_ID, DisconnectCode.NORMAL, 1));
+
+    assertRejected(channel);
+  }
+
+  @Test
+  public void outboundRejectedHelloIsNeverRegistered() throws Exception {
+    TestChannel channel = newChannel(true, 10001);
+    receive(channel, hello(NETWORK_ID, 1, DisconnectCode.TOO_MANY_PEERS, 1));
+
+    assertRejected(channel);
+  }
+
+  @Test
+  public void closingDuringHelloReplyDoesNotRegisterPeer() throws Exception {
+    TestChannel channel = newChannel(false, 10001);
+    channel.closeOnHelloReply = true;
+    receive(channel, hello(NETWORK_ID, 1, DisconnectCode.NORMAL, 1));
+
+    assertRejected(channel);
+  }
+
+  @Test
+  public void closedChannelCannotCompleteHandshake() throws Exception {
+    TestChannel channel = newChannel(true, 10001);
+    channel.close();
+    ChannelManager.processMessage(channel, hello(NETWORK_ID, 1, DisconnectCode.NORMAL, 1));
+
+    assertRejected(channel);
+  }
+
+  @Test
+  public void inboundHelloCompletesBeforeRegistration() throws Exception {
+    TestChannel channel = newChannel(false, 10001);
+    receive(channel, hello(NETWORK_ID, 1, DisconnectCode.NORMAL, 1));
+
+    assertAdmitted(channel);
+    // Hello is a plain protocol frame even when subsequent messages use compression.
+    HelloMessage reply = (HelloMessage) Message.parse(readOutbound(channel));
+    Assert.assertEquals(NETWORK_ID, reply.getNetworkId());
+    Assert.assertEquals(DisconnectCode.NORMAL.getValue().intValue(), reply.getCode());
+    receive(channel, UpgradeController.codeSendData(1, APPLICATION_MESSAGE));
+    Assert.assertEquals(Arrays.asList("connect", "message"), events);
+  }
+
+  @Test
+  public void outboundHelloCompletesBeforeRegistration() throws Exception {
+    TestChannel channel = newChannel(true, 10001);
+    ChannelManager.getHandshakeService().startHandshake(channel);
+    Assert.assertEquals(MessageType.HANDSHAKE_HELLO,
+        Message.parse(readOutbound(channel)).getType());
+    receive(channel, hello(NETWORK_ID, 1, DisconnectCode.NORMAL, 1));
+
+    assertAdmitted(channel);
+    receive(channel, UpgradeController.codeSendData(1, APPLICATION_MESSAGE));
+    Assert.assertEquals(Arrays.asList("connect", "message"), events);
+  }
+
+  @Test
+  public void connectionLimitRejectsWithoutCompletingHandshake() throws Exception {
+    config.setMaxConnections(0);
+    TestChannel channel = newChannel(false, 10001);
+    receive(channel, hello(NETWORK_ID, 1, DisconnectCode.NORMAL, 1));
+
+    assertRejected(channel);
+    HelloMessage reply = (HelloMessage) Message.parse(readOutbound(channel));
+    Assert.assertEquals(DisconnectCode.TOO_MANY_PEERS.getValue().intValue(), reply.getCode());
+  }
+
+  @Test
+  public void sameIpLimitRejectsWithoutCompletingHandshake() throws Exception {
+    config.setMaxConnectionsWithSameIp(0);
+    TestChannel channel = newChannel(false, 10001);
+    receive(channel, hello(NETWORK_ID, 1, DisconnectCode.NORMAL, 1));
+
+    assertRejected(channel);
+    HelloMessage reply = (HelloMessage) Message.parse(readOutbound(channel));
+    Assert.assertEquals(DisconnectCode.MAX_CONNECTION_WITH_SAME_IP.getValue().intValue(),
+        reply.getCode());
+  }
+
+  @Test
+  public void selfHelloIsRejectedBeforeRegistration() throws Exception {
+    TestChannel channel = newChannel(false, 10001);
+    receive(channel, hello(NETWORK_ID, 1, DisconnectCode.NORMAL, 0));
+
+    assertRejected(channel);
+    HelloMessage reply = (HelloMessage) Message.parse(readOutbound(channel));
+    Assert.assertEquals(DisconnectCode.DUPLICATE_PEER.getValue().intValue(), reply.getCode());
+  }
+
+  @Test
+  public void wrongNetworkCannotEvictAnExistingPeer() throws Exception {
+    TestChannel unverified = newChannel(false, 10001);
+    TestChannel existing = newChannel(false, 10002);
+    // Force the unverified connection to be older, so a premature processPeer would evict existing.
+    Field startTime = Channel.class.getDeclaredField("startTime");
+    startTime.setAccessible(true);
+    startTime.set(unverified, existing.getStartTime() - 1);
+    receive(existing, hello(NETWORK_ID, 1, DisconnectCode.NORMAL, 1));
+    Assert.assertTrue(existing.socket.isOpen());
+    Assert.assertTrue(existing.isFinishHandshake());
+    Assert.assertSame(existing,
+        ChannelManager.getChannels().get(existing.getInetSocketAddress()));
+    events.clear();
+
+    receive(unverified, hello(NETWORK_ID + 1, 1, DisconnectCode.NORMAL, 1));
+
+    assertRejected(unverified);
+    Assert.assertTrue(existing.socket.isOpen());
+    Assert.assertFalse(existing.isDisconnect());
+    Assert.assertEquals(1, ChannelManager.getChannels().size());
+    Assert.assertSame(existing,
+        ChannelManager.getChannels().get(existing.getInetSocketAddress()));
+  }
+
+  private void assertRejected(TestChannel channel) {
+    Assert.assertFalse(channel.socket.isOpen());
+    Assert.assertTrue(channel.isDisconnect());
+    Assert.assertFalse(channel.isFinishHandshake());
+    Assert.assertEquals(0, channel.handshakeCompletions);
+    // No close listener removes peers in this fixture: this also catches transient registration.
+    Assert.assertFalse(ChannelManager.getChannels().containsKey(channel.getInetSocketAddress()));
+    Assert.assertTrue(events.isEmpty());
+  }
+
+  private void assertAdmitted(TestChannel channel) {
+    Assert.assertTrue(channel.socket.isOpen());
+    Assert.assertTrue(channel.isFinishHandshake());
+    Assert.assertEquals(1, channel.handshakeCompletions);
+    Assert.assertFalse(channel.registeredBeforeHandshake);
+    Assert.assertSame(channel,
+        ChannelManager.getChannels().get(channel.getInetSocketAddress()));
+    Assert.assertEquals(Arrays.asList("connect"), events);
+  }
+
+  private TestChannel newChannel(boolean active, int port) {
+    InetSocketAddress address = new InetSocketAddress("127.0.0.1", port);
+    EmbeddedChannel socket = new EmbeddedChannel() {
+      @Override
+      protected SocketAddress remoteAddress0() {
+        return address;
+      }
+    };
+    sockets.add(socket);
+    TestChannel channel = new TestChannel(socket);
+    channel.init(socket.pipeline(), active ? "remote" : "", false);
+    channel.setChannelHandlerContext(socket.pipeline().context("messageHandler"));
+    return channel;
+  }
+
+  private byte[] hello(int networkId, int version, DisconnectCode code, int nodeId)
+      throws Exception {
+    byte[] id = new byte[64];
+    id[0] = (byte) nodeId;
+    Discover.Endpoint endpoint = Discover.Endpoint.newBuilder()
+        .setNodeId(ByteString.copyFrom(id))
+        .setAddress(ByteString.copyFromUtf8("127.0.0.1"))
+        .setPort(18888)
+        .build();
+    return new HelloMessage(Connect.HelloMessage.newBuilder()
+        .setFrom(endpoint)
+        .setNetworkId(networkId)
+        .setVersion(version)
+        .setCode(code.getValue())
+        .setTimestamp(System.currentTimeMillis())
+        .build().toByteArray()).getSendData();
+  }
+
+  private void receive(TestChannel channel, byte[] data) {
+    ByteBuf frame = Unpooled.buffer();
+    int length = data.length;
+    while ((length & ~0x7f) != 0) {
+      frame.writeByte((length & 0x7f) | 0x80);
+      length >>>= 7;
+    }
+    frame.writeByte(length);
+    frame.writeBytes(data);
+    channel.socket.writeInbound(frame);
+    channel.socket.checkException();
+  }
+
+  private byte[] readOutbound(TestChannel channel) throws Exception {
+    ByteBuf bytes = Unpooled.buffer();
+    try {
+      ByteBuf part;
+      while ((part = channel.socket.readOutbound()) != null) {
+        try {
+          bytes.writeBytes(part);
+        } finally {
+          part.release();
+        }
+      }
+      Assert.assertTrue("Expected an outbound protocol frame", bytes.isReadable());
+      byte[] data = new byte[bytes.readableBytes()];
+      bytes.readBytes(data);
+      CodedInputStream input = CodedInputStream.newInstance(data);
+      byte[] payload = input.readRawBytes(input.readRawVarint32());
+      Assert.assertTrue(input.isAtEnd());
+      return payload;
+    } finally {
+      bytes.release();
+    }
+  }
+
+  private void setHandshakeService(HandshakeService service) throws Exception {
+    Field field = ChannelManager.class.getDeclaredField("handshakeService");
+    field.setAccessible(true);
+    field.set(null, service);
+  }
+
+  private static class TestChannel extends Channel {
+    private final EmbeddedChannel socket;
+    private int handshakeCompletions;
+    private boolean registeredBeforeHandshake;
+    private boolean closeOnHelloReply;
+
+    private TestChannel(EmbeddedChannel socket) {
+      this.socket = socket;
+    }
+
+    @Override
+    public void send(Message message) {
+      if (closeOnHelloReply && message.getType() == MessageType.HANDSHAKE_HELLO) {
+        close();
+        return;
+      }
+      super.send(message);
+    }
+
+    @Override
+    public void setFinishHandshake(boolean finishHandshake) {
+      if (finishHandshake) {
+        handshakeCompletions++;
+        registeredBeforeHandshake =
+            ChannelManager.getChannels().containsKey(getInetSocketAddress());
+      }
+      super.setFinishHandshake(finishHandshake);
+    }
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

- Close connections that send application messages before handshake completion with `BAD_PROTOCOL`, without setting the handshake flag, registering the peer, or invoking `onConnect()` / `onMessage()`.
- Validate `networkId` for inbound and outbound HELLO messages, and validate rejection codes on outbound handshake responses, before peer admission.
- Separate admission checks (`checkPeer`) from registration (`addPeer`). Run admission checks, handshake completion, and registration under the same `ChannelManager` lock to preserve connection limits during concurrent admission. Retain the existing single-argument `processPeer` API.
- Send the inbound HELLO response before enabling negotiated message compression. Reject self-connections before registration and prevent closed connections, including those closed while sending the HELLO reply, from completing admission.

**Why are these changes required?**

Receiving an application message before libp2p HELLO currently marks the handshake as complete, registers the peer, and invokes `onConnect()` without validating the HELLO network ID. The normal HELLO path also registers the peer before checking its network ID. This PR rejects premature application messages and completes HELLO validation and handshake processing before registering the connection or notifying application handlers.

**This PR has been tested by:**

- Added 15 `EmbeddedChannel` regression tests covering premature application messages, trusted and outbound connections, network mismatches, rejected HELLO responses, admission limits, self-connections, closure during handshake, registration/callback ordering, and compression after HELLO.
- All 25 targeted tests passed locally:

  ```bash
  ./gradlew test \
    --tests org.tron.p2p.connection.HandshakeAdmissionTest \
    --tests org.tron.p2p.connection.ChannelManagerTest \
    --tests org.tron.p2p.connection.MessageTest \
    --tests org.tron.p2p.connection.message.handshake.HelloMessageTest
  ```

- Running the new regression suite against the unchanged base (`c564f26`) produced 13 failures; all 15 pass with this fix.
- A broader connection-package test run encountered the existing `ConnPoolServiceTest.getNodes_orderByUpdateTimeDesc` failure. The same failure was reproduced on the unchanged base: the test expects strict ordering while `getNodes()` shuffles candidates.

**Follow up**

Pre-handshake TCP resource quotas and absolute handshake deadlines are addressed separately in #146.

**Extra details**

Outbound handshakes now require a matching `networkId`. The legacy fallback that accepted a matching `version` despite a different or absent `networkId` is removed.
