### PR TITLE
fix(udp): limit queued pong timeout tasks

### DIFF
--- a/src/main/java/org/tron/p2p/discover/protocol/kad/KadService.java
+++ b/src/main/java/org/tron/p2p/discover/protocol/kad/KadService.java
@@ -7,8 +7,11 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executors;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import lombok.Getter;
@@ -31,6 +34,7 @@ public class KadService implements DiscoverService {
 
   private static final int MAX_NODES = 2000;
   private static final int NODES_TRIM_THRESHOLD = 3000;
+  static final int MAX_PENDING_PONG_TASKS = 2000;
   @Getter
   @Setter
   private static long pingTimeout = 15_000;
@@ -43,9 +47,11 @@ public class KadService implements DiscoverService {
 
   private Consumer<UdpEvent> messageSender;
 
+  @Getter
   private NodeTable table;
   private Node homeNode;
 
+  @Getter
   private ScheduledExecutorService pongTimer;
   private DiscoverTask discoverTask;
 
@@ -56,8 +62,17 @@ public class KadService implements DiscoverService {
     for (InetSocketAddress address : Parameter.p2pConfig.getActiveNodes()) {
       bootNodes.add(new Node(address));
     }
-    this.pongTimer = Executors.newSingleThreadScheduledExecutor(
-        BasicThreadFactory.builder().namingPattern("pongTimer").build());
+    this.pongTimer = new ScheduledThreadPoolExecutor(1,
+        BasicThreadFactory.builder().namingPattern("pongTimer").build()) {
+      @Override
+      public synchronized ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        // Keep the capacity check and enqueue atomic across discovery and retry threads.
+        if (getQueue().size() >= MAX_PENDING_PONG_TASKS) {
+          throw new RejectedExecutionException("Pong timer queue is full");
+        }
+        return super.schedule(command, delay, unit);
+      }
+    };
     this.homeNode = new Node(Parameter.p2pConfig.getNodeID(), Parameter.p2pConfig.getIp(),
         Parameter.p2pConfig.getIpv6(), Parameter.p2pConfig.getPort());
     this.table = new NodeTable(homeNode);
@@ -179,10 +194,6 @@ public class KadService implements DiscoverService {
     return ret;
   }
 
-  public NodeTable getTable() {
-    return table;
-  }
-
   public Node getPublicHomeNode() {
     return homeNode;
   }
@@ -191,10 +202,6 @@ public class KadService implements DiscoverService {
     if (Parameter.p2pConfig.isDiscoverEnable() && messageSender != null) {
       messageSender.accept(udpEvent);
     }
-  }
-
-  public ScheduledExecutorService getPongTimer() {
-    return pongTimer;
   }
 
   private void trimTable() {

--- a/src/main/java/org/tron/p2p/discover/protocol/kad/NodeHandler.java
+++ b/src/main/java/org/tron/p2p/discover/protocol/kad/NodeHandler.java
@@ -2,8 +2,11 @@ package org.tron.p2p.discover.protocol.kad;
 
 import java.net.InetSocketAddress;
 import java.util.List;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.tron.p2p.base.Parameter;
 import org.tron.p2p.discover.Node;
@@ -17,7 +20,10 @@ import org.tron.p2p.discover.socket.UdpEvent;
 @Slf4j(topic = "net")
 public class NodeHandler {
 
+  @Setter
+  @Getter
   private Node node;
+  @Getter
   private volatile State state;
   private KadService kadService;
   private NodeHandler replaceCandidate;
@@ -34,18 +40,6 @@ public class NodeHandler {
     if (node.getPreferInetSocketAddress() != null) {
       changeState(State.DISCOVERED);
     }
-  }
-
-  public Node getNode() {
-    return node;
-  }
-
-  public void setNode(Node node) {
-    this.node = node;
-  }
-
-  public State getState() {
-    return state;
   }
 
   private void challengeWith(NodeHandler replaceCandidate) {
@@ -167,16 +161,21 @@ public class NodeHandler {
     if (kadService.getPongTimer().isShutdown()) {
       return;
     }
-    kadService.getPongTimer().schedule(() -> {
-      try {
-        if (waitForPong) {
-          waitForPong = false;
-          handleTimedOut();
+    try {
+      kadService.getPongTimer().schedule(() -> {
+        try {
+          if (waitForPong) {
+            waitForPong = false;
+            handleTimedOut();
+          }
+        } catch (Exception e) {
+          log.error("Unhandled exception in pong timer schedule", e);
         }
-      } catch (Exception e) {
-        log.error("Unhandled exception in pong timer schedule", e);
-      }
-    }, KadService.getPingTimeout(), TimeUnit.MILLISECONDS);
+      }, KadService.getPingTimeout(), TimeUnit.MILLISECONDS);
+    } catch (RejectedExecutionException e) {
+      log.debug("Skip pong timeout for {}, timer stopped or queue full",
+          node.getPreferInetSocketAddress());
+    }
   }
 
   public void sendPong() {

--- a/src/test/java/org/tron/p2p/discover/protocol/kad/PongTimerTest.java
+++ b/src/test/java/org/tron/p2p/discover/protocol/kad/PongTimerTest.java
@@ -1,0 +1,159 @@
+package org.tron.p2p.discover.protocol.kad;
+
+import io.netty.buffer.Unpooled;
+import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.channel.socket.DatagramPacket;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tron.p2p.P2pConfig;
+import org.tron.p2p.base.Parameter;
+import org.tron.p2p.discover.Node;
+import org.tron.p2p.discover.message.MessageType;
+import org.tron.p2p.discover.message.kad.FindNodeMessage;
+import org.tron.p2p.discover.socket.MessageHandler;
+import org.tron.p2p.discover.socket.P2pPacketDecoder;
+
+public class PongTimerTest {
+
+  private static P2pConfig config;
+  private P2pConfig previousConfig;
+  private long previousTimeout;
+  private KadService service;
+  private ScheduledThreadPoolExecutor timer;
+
+  @BeforeClass
+  public static void createConfig() {
+    config = new P2pConfig();
+    config.setIp("127.0.0.1");
+    config.setIpv6("");
+  }
+
+  @Before
+  public void setUp() {
+    previousConfig = Parameter.p2pConfig;
+    previousTimeout = KadService.getPingTimeout();
+    Parameter.p2pConfig = config;
+    config.setDiscoverEnable(false);
+    KadService.setPingTimeout(60_000);
+    service = new KadService();
+    service.init();
+    timer = (ScheduledThreadPoolExecutor) service.getPongTimer();
+  }
+
+  @After
+  public void tearDown() {
+    service.close();
+    KadService.setPingTimeout(previousTimeout);
+    Parameter.p2pConfig = previousConfig;
+  }
+
+  @Test(timeout = 20000)
+  public void fullQueueRejectsAndAcceptsAgainAfterTaskExecutes() throws Exception {
+    CountDownLatch started = new CountDownLatch(1);
+    CountDownLatch release = new CountDownLatch(1);
+    timer.execute(() -> {
+      started.countDown();
+      try {
+        release.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    try {
+      Assert.assertTrue(started.await(5, TimeUnit.SECONDS));
+      Future<?> ready = timer.schedule(() -> { }, 0, TimeUnit.SECONDS);
+      for (int i = 1; i < KadService.MAX_PENDING_PONG_TASKS; i++) {
+        submitDelayedTask();
+      }
+      Assert.assertThrows(RejectedExecutionException.class, this::submitDelayedTask);
+      Assert.assertEquals(KadService.MAX_PENDING_PONG_TASKS, timer.getQueue().size());
+      release.countDown();
+      ready.get(5, TimeUnit.SECONDS);
+      submitDelayedTask();
+      Assert.assertEquals(KadService.MAX_PENDING_PONG_TASKS, timer.getQueue().size());
+    } finally {
+      release.countDown();
+    }
+  }
+
+  @Test(timeout = 20000)
+  public void concurrentSubmissionsRespectQueueLimit() throws Exception {
+    ExecutorService executor = Executors.newFixedThreadPool(8);
+    CountDownLatch start = new CountDownLatch(1);
+    List<Future<Integer>> results = new ArrayList<>();
+    try {
+      for (int i = 0; i < 8; i++) {
+        results.add(executor.submit(() -> {
+          Assert.assertTrue(start.await(5, TimeUnit.SECONDS));
+          int accepted = 0;
+          for (int j = 0; j < 300; j++) {
+            try {
+              submitDelayedTask();
+              accepted++;
+            } catch (RejectedExecutionException expected) {
+              // A full timer must reject without exceeding its queue limit.
+            }
+          }
+          return accepted;
+        }));
+      }
+      start.countDown();
+      int accepted = 0;
+      for (Future<Integer> result : results) {
+        accepted += result.get(10, TimeUnit.SECONDS);
+      }
+      Assert.assertEquals(KadService.MAX_PENDING_PONG_TASKS, accepted);
+      Assert.assertEquals(accepted, timer.getQueue().size());
+    } finally {
+      executor.shutdownNow();
+      Assert.assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+    }
+  }
+
+  @Test
+  public void overflowDoesNotCloseUdpChannelOrChangeNodeProcessing() {
+    AtomicInteger pings = new AtomicInteger();
+    config.setDiscoverEnable(true);
+    service.setMessageSender(event -> {
+      if (event.getMessage().getType() == MessageType.KAD_PING) {
+        pings.incrementAndGet();
+      }
+    });
+    EmbeddedChannel pipeline =
+        new EmbeddedChannel(new P2pPacketDecoder(), new MessageHandler(null, service));
+    Node from = new Node(new byte[64], "127.0.0.2", "", 18888);
+    byte[] wire = new FindNodeMessage(from, new byte[64]).getSendData();
+    try {
+      for (int i = 0; i < 4000; i++) {
+        pipeline.writeInbound(new DatagramPacket(Unpooled.wrappedBuffer(wire),
+            new InetSocketAddress("127.0.0.1", 18888),
+            new InetSocketAddress("127.0.0.2", 20000 + i)));
+      }
+      pipeline.checkException();
+      Assert.assertTrue(pipeline.isActive());
+      Assert.assertEquals(KadService.MAX_PENDING_PONG_TASKS, timer.getQueue().size());
+      Assert.assertEquals(4000, pings.get());
+      Assert.assertEquals(999, service.getAllNodes().size());
+    } finally {
+      pipeline.finishAndReleaseAll();
+    }
+  }
+
+  private void submitDelayedTask() {
+    timer.schedule(() -> { }, 60, TimeUnit.SECONDS);
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

- Add the fixed constant `MAX_PENDING_PONG_TASKS = 2000`. Serialize the capacity check and enqueue operation in the `schedule(Runnable, ...)` entry point used by discovery timeouts, so concurrent receive and retry threads cannot exceed the queue limit. Capacity becomes available again as tasks leave the queue.
- Catch `RejectedExecutionException` in `NodeHandler.sendPing()`. When the queue is full or the executor stops, skip the timeout task and log at debug level instead of propagating the exception into the UDP channel's error handler.
- Keep the change limited to timeout scheduling and rejection handling, with no new configuration options. Existing accessor methods are replaced with equivalent Lombok-generated accessors.

**Why are these changes required?**

UDP discovery creates a pong timeout task for each newly observed endpoint. Removing handlers from the node map does not cancel these tasks, so the scheduler can retain handlers beyond the map's trimming limits. This PR provides a focused mitigation for that timeout backlog by limiting queued tasks and handling overflow safely.

**This PR has been tested by:**

Added 3 regression tests covering queue overflow, reuse of capacity after execution, concurrent submissions, and continued UDP processing under saturation.

The decoder-path test processes 4,000 valid datagrams from distinct source ports on the same IP. The queue stays at 2,000 tasks and the channel remains active. It also confirms the remaining scope: all 4,000 initial pings are emitted and the existing map trimming leaves 999 handlers. Outbound delivery is captured in-process; this is not a resource-exhaustion load test.

All 27 discovery tests passed locally on `7f644ed`:

```bash
./gradlew test --tests 'org.tron.p2p.discover.*' --console=plain
```

**Follow up**

- **Return-path verification:** new endpoints still create `NodeHandler` state before proving they can receive and respond to a challenge.
- **Admission and rate limits:** there is no new per-IP limit, endpoint creation rate limit, or independent quota for unverified handlers. The existing node-map trimming behavior remains in place.
- **Initial processing and outbound traffic:** the initial ping is sent before timeout scheduling. Rejecting a timeout task does not prevent packet parsing, handler creation, map trimming, or that outbound ping.
- **Task lifecycle cleanup:** node-map trimming and receiving a PONG still do not cancel and remove already queued tasks. Accepted tasks can continue retaining removed handlers and performing retries under the existing retry rules, subject to the queue limit.
- **Availability under saturation:** unverified endpoints can occupy the shared timeout capacity, causing legitimate probes' timeout/retry scheduling to be rejected as well. The cap bounds the queued timeout backlog but does not fully address UDP discovery resource exhaustion or ensure fair admission.

**Extra details**

The limit applies to queued pong timeout tasks; an executing callback is outside that count. It is enforced at the submission entry point used by discovery, rather than by replacing the JDK executor's internal queue.
