### PR TITLE
feat(tcp): valid node more strictly

### DIFF
--- a/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
+++ b/src/main/java/org/tron/p2p/connection/business/pool/ConnPoolService.java
@@ -113,12 +113,19 @@ public class ConnPoolService extends P2pEventHandler {
     Set<String> nodesInUse = new HashSet<>();
     nodesInUse.add(Hex.toHexString(p2pConfig.getNodeID()));
     ChannelManager.getChannels().values().forEach(channel -> {
+      Node node = channel.getNode();
+      if (node != null && !NetUtil.validPort(node.getPort())) {
+        log.warn("Close peer {} with invalid advertised port {}",
+            channel.getInetSocketAddress(), node.getPort());
+        channel.close();
+        return;
+      }
       if (StringUtils.isNotEmpty(channel.getNodeId())) {
         nodesInUse.add(channel.getNodeId());
       }
       addressInUse.add(channel.getInetAddress());
       inetInUse.add(channel.getInetSocketAddress());
-      addNode(inetInUse, channel.getNode());
+      addNode(inetInUse, node);
     });
 
     addNode(inetInUse, new Node(Parameter.p2pConfig.getNodeID(), Parameter.p2pConfig.getIp(),
@@ -228,8 +235,14 @@ public class ConnPoolService extends P2pEventHandler {
 
   private boolean validNode(Node node, Set<String> nodesInUse, Set<InetSocketAddress> inetInUse,
       Set<InetSocketAddress> dynamicInet) {
+    if (node == null || !NetUtil.validPort(node.getPort())) {
+      return false;
+    }
     long now = System.currentTimeMillis();
     InetSocketAddress inetSocketAddress = node.getPreferInetSocketAddress();
+    if (inetSocketAddress == null || inetSocketAddress.isUnresolved()) {
+      return false;
+    }
     InetAddress inetAddress = inetSocketAddress.getAddress();
     Long forbiddenTime = ChannelManager.getBannedNodes().getIfPresent(inetAddress);
     if ((forbiddenTime != null && now <= forbiddenTime)

--- a/src/main/java/org/tron/p2p/discover/Node.java
+++ b/src/main/java/org/tron/p2p/discover/Node.java
@@ -96,7 +96,7 @@ public class Node implements Serializable, Cloneable {
         this.hostV6 = null;
         return;
       }
-      InetAddress address = new InetSocketAddress(hostV6, port).getAddress();
+      InetAddress address = new InetSocketAddress(hostV6, 0).getAddress();
       this.hostV6 = address == null ? null : address.getHostAddress();
     }
   }
@@ -177,11 +177,13 @@ public class Node implements Serializable, Cloneable {
   }
 
   public InetSocketAddress getInetSocketAddressV4() {
-    return StringUtils.isNotEmpty(hostV4) ? new InetSocketAddress(hostV4, port) : null;
+    return StringUtils.isNotEmpty(hostV4) && NetUtil.validPort(port)
+        ? new InetSocketAddress(hostV4, port) : null;
   }
 
   public InetSocketAddress getInetSocketAddressV6() {
-    return StringUtils.isNotEmpty(hostV6) ? new InetSocketAddress(hostV6, port) : null;
+    return StringUtils.isNotEmpty(hostV6) && NetUtil.validPort(port)
+        ? new InetSocketAddress(hostV6, port) : null;
   }
 
   @Override

--- a/src/main/java/org/tron/p2p/discover/Node.java
+++ b/src/main/java/org/tron/p2p/discover/Node.java
@@ -96,7 +96,7 @@ public class Node implements Serializable, Cloneable {
         this.hostV6 = null;
         return;
       }
-      InetAddress address = new InetSocketAddress(hostV6, 0).getAddress();
+      InetAddress address = new InetSocketAddress(hostV6, port).getAddress();
       this.hostV6 = address == null ? null : address.getHostAddress();
     }
   }

--- a/src/main/java/org/tron/p2p/utils/NetUtil.java
+++ b/src/main/java/org/tron/p2p/utils/NetUtil.java
@@ -60,7 +60,7 @@ public class NetUtil {
   }
 
   public static boolean validPort(int port) {
-    return port > 0 && port <= 65535;
+    return port > 0 && port <= 0xFFFF;
   }
 
   public static boolean validNode(Node node) {

--- a/src/main/java/org/tron/p2p/utils/NetUtil.java
+++ b/src/main/java/org/tron/p2p/utils/NetUtil.java
@@ -59,11 +59,15 @@ public class NetUtil {
     return PATTERN_IPv6.matcher(ip).matches();
   }
 
+  public static boolean validPort(int port) {
+    return port > 0 && port <= 65535;
+  }
+
   public static boolean validNode(Node node) {
     if (node == null || node.getId() == null) {
       return false;
     }
-    if (node.getId().length != Constant.NODE_ID_LEN) {
+    if (node.getId().length != Constant.NODE_ID_LEN || !validPort(node.getPort())) {
       return false;
     }
     if (StringUtils.isEmpty(node.getHostV4()) && StringUtils.isEmpty(node.getHostV6())) {

--- a/src/test/java/org/tron/p2p/connection/ConnPoolPortValidationTest.java
+++ b/src/test/java/org/tron/p2p/connection/ConnPoolPortValidationTest.java
@@ -1,0 +1,144 @@
+package org.tron.p2p.connection;
+
+import com.google.protobuf.ByteString;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.embedded.EmbeddedChannel;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.tron.p2p.P2pConfig;
+import org.tron.p2p.P2pEventHandler;
+import org.tron.p2p.base.Parameter;
+import org.tron.p2p.connection.business.handshake.DisconnectCode;
+import org.tron.p2p.connection.business.pool.ConnPoolService;
+import org.tron.p2p.connection.message.handshake.HelloMessage;
+import org.tron.p2p.connection.socket.PeerClient;
+import org.tron.p2p.discover.Node;
+import org.tron.p2p.dns.DnsNode;
+import org.tron.p2p.protos.Connect;
+import org.tron.p2p.protos.Discover;
+
+public class ConnPoolPortValidationTest {
+
+  private final InetSocketAddress candidate = new InetSocketAddress("127.0.0.3", 18888);
+  private final List<Node> dialed = new ArrayList<>();
+  private final List<EmbeddedChannel> sockets = new ArrayList<>();
+  private P2pConfig previousConfig;
+  private List<P2pEventHandler> previousHandlers;
+  private Map<InetSocketAddress, Channel> previousChannels;
+  private Map<InetAddress, Long> previousBans;
+  private ConnPoolService pool;
+
+  @Before
+  public void init() throws Exception {
+    previousConfig = Parameter.p2pConfig;
+    previousHandlers = Parameter.handlerList;
+    previousChannels = new HashMap<>(ChannelManager.getChannels());
+    previousBans = new HashMap<>(ChannelManager.getBannedNodes().asMap());
+    Parameter.p2pConfig = new P2pConfig();
+    Parameter.p2pConfig.setIp("127.0.0.1");
+    Parameter.p2pConfig.setIpv6("");
+    Parameter.p2pConfig.setMinConnections(0);
+    Parameter.p2pConfig.setMinActiveConnections(0);
+    Parameter.p2pConfig.getActiveNodes().add(candidate);
+    Parameter.handlerList = new ArrayList<>();
+    ChannelManager.getChannels().clear();
+    ChannelManager.getBannedNodes().invalidateAll();
+    pool = new ConnPoolService();
+    Field client = ConnPoolService.class.getDeclaredField("peerClient");
+    client.setAccessible(true);
+    client.set(pool, new PeerClient() {
+      @Override
+      public ChannelFuture connectAsync(Node node, boolean discoveryMode) {
+        dialed.add(node);
+        return null;
+      }
+    });
+  }
+
+  @After
+  public void destroy() {
+    sockets.forEach(EmbeddedChannel::finishAndReleaseAll);
+    if (pool != null) {
+      pool.close();
+    }
+    ChannelManager.getChannels().clear();
+    ChannelManager.getChannels().putAll(previousChannels);
+    ChannelManager.getBannedNodes().invalidateAll();
+    ChannelManager.getBannedNodes().putAll(previousBans);
+    Parameter.handlerList = previousHandlers;
+    Parameter.p2pConfig = previousConfig;
+  }
+
+  @Test
+  public void poisonedChannelDoesNotPreventDialing() throws Exception {
+    Channel healthy = registerChannel(18888, 20000);
+    for (int port : new int[]{70000, 0, -1, 65536, Integer.MIN_VALUE, Integer.MAX_VALUE}) {
+      Channel poisoned = registerChannel(port, 20001);
+      Method connect = ConnPoolService.class.getDeclaredMethod("connect", boolean.class);
+      connect.setAccessible(true);
+      connect.invoke(pool, false);
+
+      Assert.assertTrue(poisoned.isDisconnect());
+      Assert.assertFalse(poisoned.getCtx().channel().isOpen());
+      Assert.assertFalse(ChannelManager.getChannels().containsKey(poisoned.getInetSocketAddress()));
+      Assert.assertTrue(healthy.getCtx().channel().isOpen());
+      Assert.assertSame(healthy, ChannelManager.getChannels().get(healthy.getInetSocketAddress()));
+      Assert.assertEquals(candidate, dialed.get(dialed.size() - 1).getPreferInetSocketAddress());
+      ChannelManager.getBannedNodes().invalidateAll();
+    }
+    Assert.assertEquals(6, dialed.size());
+  }
+
+  @Test
+  public void invalidCandidatesAreSkippedAndDnsNodesRemainEligible() throws Exception {
+    Node good = new Node(new byte[64], "127.0.0.4", "", 65535);
+    DnsNode dns = new DnsNode(null, "127.0.0.5", "", 1);
+    List<Node> candidates = new ArrayList<>(Arrays.asList(good, dns, null,
+        new Node(new byte[64], "", "2001:db8::1", 18888)));
+    for (int port : new int[]{0, -1, 65536, 70000, Integer.MIN_VALUE, Integer.MAX_VALUE}) {
+      candidates.add(new Node(new byte[64], "127.0.0.6", "", port));
+    }
+    List<Node> selected = pool.getNodes(new HashSet<>(), new HashSet<>(), candidates, 10);
+    Assert.assertEquals(2, selected.size());
+    Assert.assertTrue(selected.contains(good));
+    Assert.assertTrue(selected.contains(dns));
+    Assert.assertNull(dns.getId());
+  }
+
+  private Channel registerChannel(int port, int sourcePort) throws Exception {
+    EmbeddedChannel socket = new EmbeddedChannel(new ChannelInboundHandlerAdapter()) {
+      @Override
+      protected SocketAddress remoteAddress0() {
+        return new InetSocketAddress("127.0.0.2", sourcePort);
+      }
+    };
+    sockets.add(socket);
+    Channel channel = new Channel();
+    channel.setChannelHandlerContext(socket.pipeline().firstContext());
+    byte[] id = new byte[64];
+    id[0] = (byte) sourcePort;
+    Discover.Endpoint endpoint = Discover.Endpoint.newBuilder().setNodeId(ByteString.copyFrom(id))
+        .setAddress(ByteString.copyFromUtf8("1.2.3.4")).setPort(port).build();
+    // Deliberately bypass wire validation to exercise defense against existing bad state.
+    channel.setHelloMessage(new HelloMessage(Connect.HelloMessage.newBuilder()
+        .setFrom(endpoint).build().toByteArray()));
+    socket.closeFuture().addListener(future -> ChannelManager.notifyDisconnect(channel));
+    Assert.assertEquals(DisconnectCode.NORMAL, ChannelManager.processPeer(channel));
+    pool.onConnect(channel);
+    return channel;
+  }
+}

--- a/src/test/java/org/tron/p2p/connection/MessageTest.java
+++ b/src/test/java/org/tron/p2p/connection/MessageTest.java
@@ -3,6 +3,7 @@ package org.tron.p2p.connection;
 
 import static org.tron.p2p.base.Parameter.NETWORK_TIME_DIFF;
 
+import com.google.protobuf.ByteString;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,6 +12,7 @@ import org.tron.p2p.base.Parameter;
 import org.tron.p2p.connection.business.handshake.DisconnectCode;
 import org.tron.p2p.connection.message.Message;
 import org.tron.p2p.connection.message.MessageType;
+import org.tron.p2p.connection.message.detect.StatusMessage;
 import org.tron.p2p.connection.message.handshake.HelloMessage;
 import org.tron.p2p.connection.message.keepalive.PingMessage;
 import org.tron.p2p.connection.message.keepalive.PongMessage;
@@ -18,6 +20,7 @@ import org.tron.p2p.exception.P2pException;
 import org.tron.p2p.exception.P2pException.TypeEnum;
 import org.tron.p2p.protos.Connect;
 import org.tron.p2p.protos.Connect.KeepAliveMessage;
+import org.tron.p2p.protos.Discover;
 
 public class MessageTest {
 
@@ -60,6 +63,47 @@ public class MessageTest {
     } catch (P2pException e) {
       Assert.fail();
     }
+  }
+
+  @Test
+  public void testInvalidEndpointPorts() throws Exception {
+    for (int port : new int[]{0, -1, 65536, 70000, Integer.MIN_VALUE, Integer.MAX_VALUE}) {
+      for (String ipv6 : new String[]{"", "2001:db8::1"}) {
+        Discover.Endpoint endpoint = endpoint(port, ipv6);
+        HelloMessage hello = new HelloMessage(Connect.HelloMessage.newBuilder()
+            .setFrom(endpoint).setNetworkId(Parameter.p2pConfig.getNetworkId())
+            .build().toByteArray());
+        StatusMessage status = new StatusMessage(Connect.StatusMessage.newBuilder()
+            .setFrom(endpoint).build().toByteArray());
+        for (Message message : new Message[]{hello, status}) {
+          P2pException error = Assert.assertThrows(P2pException.class,
+              () -> Message.parse(message.getSendData()));
+          Assert.assertEquals(TypeEnum.BAD_MESSAGE, error.getType());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testValidEndpointBoundaryPorts() throws Exception {
+    for (int port : new int[]{1, 65535}) {
+      for (String ipv6 : new String[]{"", "2001:db8::1"}) {
+        Discover.Endpoint endpoint = endpoint(port, ipv6);
+        HelloMessage hello = new HelloMessage(Connect.HelloMessage.newBuilder()
+            .setFrom(endpoint).build().toByteArray());
+        StatusMessage status = new StatusMessage(Connect.StatusMessage.newBuilder()
+            .setFrom(endpoint).build().toByteArray());
+        Assert.assertEquals(MessageType.HANDSHAKE_HELLO,
+            Message.parse(hello.getSendData()).getType());
+        Assert.assertEquals(MessageType.STATUS, Message.parse(status.getSendData()).getType());
+      }
+    }
+  }
+
+  private Discover.Endpoint endpoint(int port, String ipv6) {
+    return Discover.Endpoint.newBuilder().setNodeId(ByteString.copyFrom(new byte[64]))
+        .setAddress(ByteString.copyFromUtf8("1.2.3.4"))
+        .setAddressIpv6(ByteString.copyFromUtf8(ipv6)).setPort(port).build();
   }
 
   @Test

--- a/src/test/java/org/tron/p2p/discover/NodeTest.java
+++ b/src/test/java/org/tron/p2p/discover/NodeTest.java
@@ -47,6 +47,29 @@ public class NodeTest {
   }
 
   @Test
+  public void invalidPortDoesNotBreakIpv6Normalization() {
+    Parameter.p2pConfig.setIp("127.0.0.1");
+    Parameter.p2pConfig.setIpv6("::1");
+    for (int port : new int[]{0, -1, 65536, 70000, Integer.MIN_VALUE, Integer.MAX_VALUE}) {
+      Node node = new Node(new byte[64], "1.2.3.4", "2001:db8::1", port);
+      Assert.assertEquals("2001:db8:0:0:0:0:0:1", node.getHostV6());
+      Assert.assertEquals(port, node.getPort());
+      Assert.assertNull(node.getInetSocketAddressV4());
+      Assert.assertNull(node.getInetSocketAddressV6());
+      Assert.assertNull(node.getPreferInetSocketAddress());
+    }
+  }
+
+  @Test
+  public void validBoundaryPortsProduceSocketAddresses() {
+    for (int port : new int[]{1, 65535}) {
+      Node node = new Node(new byte[64], "1.2.3.4", "2001:db8::1", port);
+      Assert.assertEquals(port, node.getInetSocketAddressV4().getPort());
+      Assert.assertEquals(port, node.getInetSocketAddressV6().getPort());
+    }
+  }
+
+  @Test
   public void ipV4CompatibleTest() {
     Parameter.p2pConfig.setIp("127.0.0.1");
     Parameter.p2pConfig.setIpv6(null);

--- a/src/test/java/org/tron/p2p/discover/message/PortValidationTest.java
+++ b/src/test/java/org/tron/p2p/discover/message/PortValidationTest.java
@@ -1,0 +1,68 @@
+package org.tron.p2p.discover.message;
+
+import com.google.protobuf.ByteString;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tron.p2p.discover.message.kad.FindNodeMessage;
+import org.tron.p2p.discover.message.kad.NeighborsMessage;
+import org.tron.p2p.discover.message.kad.PingMessage;
+import org.tron.p2p.discover.message.kad.PongMessage;
+import org.tron.p2p.exception.P2pException;
+import org.tron.p2p.exception.P2pException.TypeEnum;
+import org.tron.p2p.protos.Discover;
+
+public class PortValidationTest {
+
+  @Test
+  public void invalidSenderPortsAreRejected() throws Exception {
+    for (int port : new int[]{0, -1, 65536, 70000, Integer.MIN_VALUE, Integer.MAX_VALUE}) {
+      for (String ipv6 : new String[]{"", "2001:db8::1"}) {
+        for (Message message : messages(endpoint(port, ipv6), endpoint(18888, ""))) {
+          assertBadMessage(message);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void invalidNeighborPortsAreRejected() throws Exception {
+    NeighborsMessage message = new NeighborsMessage(Discover.Neighbours.newBuilder()
+        .setFrom(endpoint(18888, "")).addNeighbours(endpoint(70000, ""))
+        .build().toByteArray());
+    assertBadMessage(message);
+  }
+
+  @Test
+  public void validBoundaryPortsAreAccepted() throws Exception {
+    for (int port : new int[]{1, 65535}) {
+      for (String ipv6 : new String[]{"", "2001:db8::1"}) {
+        Discover.Endpoint endpoint = endpoint(port, ipv6);
+        for (Message message : messages(endpoint, endpoint)) {
+          Assert.assertEquals(message.getType(), Message.parse(message.getSendData()).getType());
+        }
+      }
+    }
+  }
+
+  private void assertBadMessage(Message message) {
+    P2pException error = Assert.assertThrows(P2pException.class,
+        () -> Message.parse(message.getSendData()));
+    Assert.assertEquals(TypeEnum.BAD_MESSAGE, error.getType());
+  }
+
+  private Discover.Endpoint endpoint(int port, String ipv6) {
+    return Discover.Endpoint.newBuilder().setNodeId(ByteString.copyFrom(new byte[64]))
+        .setAddress(ByteString.copyFromUtf8("1.2.3.4"))
+        .setAddressIpv6(ByteString.copyFromUtf8(ipv6)).setPort(port).build();
+  }
+
+  private Message[] messages(Discover.Endpoint from, Discover.Endpoint neighbor) throws Exception {
+    return new Message[]{
+        new PingMessage(Discover.PingMessage.newBuilder().setFrom(from).build().toByteArray()),
+        new PongMessage(Discover.PongMessage.newBuilder().setFrom(from).build().toByteArray()),
+        new FindNodeMessage(Discover.FindNeighbours.newBuilder().setFrom(from)
+            .setTargetId(ByteString.copyFrom(new byte[64])).build().toByteArray()),
+        new NeighborsMessage(Discover.Neighbours.newBuilder().setFrom(from)
+            .addNeighbours(neighbor).build().toByteArray())};
+  }
+}

--- a/src/test/java/org/tron/p2p/utils/NetUtilTest.java
+++ b/src/test/java/org/tron/p2p/utils/NetUtilTest.java
@@ -68,6 +68,20 @@ public class NetUtilTest {
   }
 
   @Test
+  public void testValidPort() {
+    for (int port : new int[]{0, -1, 65536, 70000, Integer.MIN_VALUE, Integer.MAX_VALUE}) {
+      Assert.assertFalse("port=" + port, NetUtil.validPort(port));
+      Assert.assertFalse(NetUtil.validNode(new Node(new byte[64], "1.2.3.4", "", port)));
+      Assert.assertFalse(NetUtil.validNode(new Node(new byte[64], "", "2001:db8::1", port)));
+    }
+    for (int port : new int[]{1, 65535}) {
+      Assert.assertTrue("port=" + port, NetUtil.validPort(port));
+      Assert.assertTrue(NetUtil.validNode(new Node(new byte[64], "1.2.3.4", "", port)));
+      Assert.assertTrue(NetUtil.validNode(new Node(new byte[64], "", "2001:db8::1", port)));
+    }
+  }
+
+  @Test
   public void testGetNode() {
     Discover.Endpoint endpoint = Discover.Endpoint.newBuilder()
         .setPort(100).build();


### PR DESCRIPTION
**What does this PR do?**

- Reuse a shared service-port check during node validation.
- Keep IPv6 normalization independent of service-port handling.
- Improve connection-pool handling of unusable node records and candidates while preserving DNS candidate support.

**Why are these changes required?**

Node endpoint validation and address handling should apply consistent rules across networking components, and unusable node records should be handled locally during candidate processing.

**This PR has been tested by:**

- 47 focused tests passed, covering endpoint boundaries, IPv4/IPv6 handling, message validation, connection-pool behavior, and DNS candidates. `git diff --check` passed.

**Follow up**

None.

**Extra details**

IPv6 normalization is independent of service-port handling, and the connection pool continues to support DNS candidates.
