### PR TITLE
fix(startup): fail on initial TCP or UDP bind errors

### DIFF
--- a/src/main/java/org/tron/p2p/P2pService.java
+++ b/src/main/java/org/tron/p2p/P2pService.java
@@ -26,12 +26,20 @@ public class P2pService {
 
   public void start(P2pConfig p2pConfig) {
     Parameter.p2pConfig = p2pConfig;
-    NodeManager.init();
-    ChannelManager.init();
-    DnsManager.init();
-    log.info("P2p service started");
-
-    Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+    try {
+      NodeManager.init();
+      ChannelManager.init();
+      DnsManager.init();
+      Runtime.getRuntime().addShutdownHook(new Thread(this::close));
+      log.info("P2p service started");
+    } catch (RuntimeException e) {
+      try {
+        close();
+      } catch (RuntimeException cleanupError) {
+        e.addSuppressed(cleanupError);
+      }
+      throw e;
+    }
   }
 
   public void close() {

--- a/src/main/java/org/tron/p2p/connection/socket/PeerClient.java
+++ b/src/main/java/org/tron/p2p/connection/socket/PeerClient.java
@@ -27,8 +27,10 @@ public class PeerClient {
   }
 
   public void close() {
-    workerGroup.shutdownGracefully();
-    workerGroup.terminationFuture().syncUninterruptibly();
+    if (workerGroup != null) {
+      workerGroup.shutdownGracefully();
+      workerGroup.terminationFuture().syncUninterruptibly();
+    }
   }
 
   public void connect(String host, int port, String remoteId) {

--- a/src/main/java/org/tron/p2p/connection/socket/PeerServer.java
+++ b/src/main/java/org/tron/p2p/connection/socket/PeerServer.java
@@ -17,34 +17,42 @@ import org.tron.p2p.base.Parameter;
 public class PeerServer {
 
   private ChannelFuture channelFuture;
-  private boolean listening;
+  private EventLoopGroup bossGroup;
+  private EventLoopGroup workerGroup;
 
   public void init() {
     int port = Parameter.p2pConfig.getPort();
     if (port > 0) {
-      new Thread(() -> start(port), "PeerServer").start();
+      start(port);
     }
   }
 
   public void close() {
-    if (listening && channelFuture != null && channelFuture.channel().isOpen()) {
-      try {
+    try {
+      if (channelFuture != null && channelFuture.channel().isOpen()) {
         log.info("Closing TCP server...");
-        channelFuture.channel().close().sync();
-      } catch (Exception e) {
-        log.warn("Closing TCP server failed.", e);
+        channelFuture.channel().close().syncUninterruptibly();
+      }
+    } catch (Exception e) {
+      log.warn("Closing TCP server failed.", e);
+    } finally {
+      if (workerGroup != null) {
+        workerGroup.shutdownGracefully();
+      }
+      if (bossGroup != null) {
+        bossGroup.shutdownGracefully();
       }
     }
   }
 
   public void start(int port) {
-    EventLoopGroup bossGroup = new NioEventLoopGroup(1,
-        BasicThreadFactory.builder().namingPattern("peerBoss").build());
-    //if threads = 0, it is number of core * 2
-    EventLoopGroup workerGroup = new NioEventLoopGroup(Parameter.TCP_NETTY_WORK_THREAD_NUM,
-        BasicThreadFactory.builder().namingPattern("peerWorker-%d").build());
-    P2pChannelInitializer p2pChannelInitializer = new P2pChannelInitializer("", false, true);
     try {
+      bossGroup = new NioEventLoopGroup(1,
+          BasicThreadFactory.builder().namingPattern("peerBoss").build());
+      //if threads = 0, it is number of core * 2
+      workerGroup = new NioEventLoopGroup(Parameter.TCP_NETTY_WORK_THREAD_NUM,
+          BasicThreadFactory.builder().namingPattern("peerWorker-%d").build());
+      P2pChannelInitializer p2pChannelInitializer = new P2pChannelInitializer("", false, true);
       ServerBootstrap b = new ServerBootstrap();
 
       b.group(bossGroup, workerGroup);
@@ -56,24 +64,16 @@ public class PeerServer {
       b.handler(new LoggingHandler());
       b.childHandler(p2pChannelInitializer);
 
-      // Start the client.
+      // Retain the channel before waiting so an interrupted bind can also be closed.
+      channelFuture = b.bind(port);
+      channelFuture.sync();
       log.info("TCP listener started, bind port {}", port);
-
-      channelFuture = b.bind(port).sync();
-
-      listening = true;
-
-      // Wait until the connection is closed.
-      channelFuture.channel().closeFuture().sync();
-
-      log.info("TCP listener closed");
-
     } catch (Exception e) {
-      log.error("Start TCP server failed", e);
-    } finally {
-      workerGroup.shutdownGracefully();
-      bossGroup.shutdownGracefully();
-      listening = false;
+      if (e instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
+      close();
+      throw new IllegalStateException("Failed to bind TCP listener on port " + port, e);
     }
   }
 

--- a/src/main/java/org/tron/p2p/discover/socket/DiscoverServer.java
+++ b/src/main/java/org/tron/p2p/discover/socket/DiscoverServer.java
@@ -16,7 +16,7 @@ import org.tron.p2p.stats.TrafficStats;
 @Slf4j(topic = "net")
 public class DiscoverServer {
 
-  private Channel channel;
+  private volatile Channel channel;
   private EventHandler eventHandler;
 
   private final int SERVER_RESTART_WAIT = 5000;
@@ -40,7 +40,7 @@ public class DiscoverServer {
     shutdown = true;
     if (channel != null) {
       try {
-        channel.close().await(SERVER_CLOSE_WAIT, TimeUnit.SECONDS);
+        channel.close().awaitUninterruptibly(SERVER_CLOSE_WAIT, TimeUnit.SECONDS);
       } catch (Exception e) {
         log.error("Closing discovery server failed", e);
       }
@@ -70,6 +70,10 @@ public class DiscoverServer {
             });
 
         channel = b.bind(port).sync().channel();
+        if (shutdown) {
+          channel.close().sync();
+          break;
+        }
 
         log.info("Discovery server started, bind port {}", port);
 

--- a/src/main/java/org/tron/p2p/example/StartApp.java
+++ b/src/main/java/org/tron/p2p/example/StartApp.java
@@ -102,7 +102,15 @@ public class StartApp {
 
     app.checkDnsOption(cli);
 
-    p2pService.start(Parameter.p2pConfig);
+    try {
+      p2pService.start(Parameter.p2pConfig);
+    } catch (RuntimeException e) {
+      log.error("P2P service startup failed", e);
+      // The standalone app may run without an SLF4J logging implementation.
+      System.err.println("P2P service startup failed: " + e.getMessage());
+      System.exit(1);
+      return;
+    }
 
     while (true) {
       try {

--- a/src/test/java/org/tron/p2p/StartupTest.java
+++ b/src/test/java/org/tron/p2p/StartupTest.java
@@ -1,0 +1,149 @@
+package org.tron.p2p;
+
+import java.io.File;
+import java.lang.reflect.Field;
+import java.net.BindException;
+import java.net.ServerSocket;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tron.p2p.connection.ChannelManager;
+import org.tron.p2p.example.StartApp;
+
+public class StartupTest {
+
+  @Test(timeout = 45000)
+  public void bindFailureReachesCallerAndDoesNotLeaveProcessRunning() throws Exception {
+    try (ServerSocket occupied = new ServerSocket(0)) {
+      String output = run(StartupProbe.class, 0, "failure",
+          Integer.toString(occupied.getLocalPort()));
+      Assert.assertTrue(output.contains("BIND_FAILURE_PROPAGATED"));
+    }
+  }
+
+  @Test(timeout = 45000)
+  public void cleanupFailureDoesNotReplaceBindFailure() throws Exception {
+    try (ServerSocket occupied = new ServerSocket(0)) {
+      String output = run(StartupProbe.class, 0, "cleanup-failure",
+          Integer.toString(occupied.getLocalPort()));
+      Assert.assertTrue(output.contains("BIND_FAILURE_PROPAGATED"));
+    }
+  }
+
+  @Test(timeout = 45000)
+  public void startAppExitsWithFailureStatusWhenPortIsOccupied() throws Exception {
+    try (ServerSocket occupied = new ServerSocket(0)) {
+      String output = run(StartApp.class, 1, "-p", Integer.toString(occupied.getLocalPort()));
+      Assert.assertTrue(output.contains("P2P service startup failed"));
+      Assert.assertTrue(output.contains(Integer.toString(occupied.getLocalPort())));
+    }
+  }
+
+  @Test(timeout = 45000)
+  public void successfulServiceCanStartAndClose() throws Exception {
+    Assert.assertTrue(run(StartupProbe.class, 0, "success").contains("STARTED_AND_CLOSED"));
+  }
+
+  private String run(Class<?> mainClass, int expectedExit, String... args) throws Exception {
+    List<String> command = new ArrayList<>();
+    command.add(new File(System.getProperty("java.home"), "bin/java").getPath());
+    command.add("-Dio.netty.eventLoopThreads=2");
+    command.add("-cp");
+    command.add(classPath());
+    command.add(mainClass.getName());
+    command.addAll(Arrays.asList(args));
+    Path outputFile = Files.createTempFile("libp2p-startup-test-", ".log");
+    Process process = null;
+    try {
+      process = new ProcessBuilder(command).redirectErrorStream(true)
+          .redirectOutput(outputFile.toFile()).start();
+      boolean exited = process.waitFor(35, TimeUnit.SECONDS);
+      String output = new String(Files.readAllBytes(outputFile), StandardCharsets.UTF_8);
+      Assert.assertTrue("Process did not exit; startup resources may remain active:\n" + output,
+          exited);
+      Assert.assertEquals(output, expectedExit, process.exitValue());
+      return output;
+    } finally {
+      if (process != null && process.isAlive()) {
+        process.destroyForcibly();
+        process.waitFor(5, TimeUnit.SECONDS);
+      }
+      Files.deleteIfExists(outputFile);
+    }
+  }
+
+  private String classPath() throws Exception {
+    Set<String> paths = new LinkedHashSet<>();
+    paths.addAll(Arrays.asList(System.getProperty("java.class.path").split(File.pathSeparator)));
+    for (ClassLoader loader = getClass().getClassLoader(); loader != null;
+        loader = loader.getParent()) {
+      if (loader instanceof URLClassLoader) {
+        for (URL url : ((URLClassLoader) loader).getURLs()) {
+          if ("file".equals(url.getProtocol())) {
+            paths.add(new File(url.toURI()).getPath());
+          }
+        }
+      }
+    }
+    return String.join(File.pathSeparator, paths);
+  }
+
+  // Runs in a separate JVM so natural process exit verifies cleanup of non-daemon threads.
+  public static class StartupProbe {
+
+    public static void main(String[] args) throws Exception {
+      P2pConfig config = new P2pConfig();
+      config.setIp("127.0.0.1");
+      config.setIpv6("");
+      config.setMinConnections(0);
+      config.setMinActiveConnections(0);
+      config.setDiscoverEnable(true);
+      boolean cleanupFailure = "cleanup-failure".equals(args[0]);
+      RuntimeException cleanupError = new IllegalStateException("Cleanup test failure");
+      P2pService service = cleanupFailure ? new P2pService() {
+        @Override
+        public void close() {
+          super.close();
+          throw cleanupError;
+        }
+      } : new P2pService();
+      if ("success".equals(args[0])) {
+        try (ServerSocket available = new ServerSocket(0)) {
+          config.setPort(available.getLocalPort());
+        }
+        service.start(config);
+        Assert.assertFalse(ChannelManager.isShutdown);
+        service.close();
+        service.close();
+        System.out.println("STARTED_AND_CLOSED");
+        return;
+      }
+
+      config.setPort(Integer.parseInt(args[1]));
+      IllegalStateException error = Assert.assertThrows(IllegalStateException.class,
+          () -> service.start(config));
+      Assert.assertTrue(error.getCause() instanceof BindException);
+      Assert.assertTrue(ChannelManager.isShutdown);
+      Field workerGroup = ChannelManager.getPeerClient().getClass().getDeclaredField("workerGroup");
+      workerGroup.setAccessible(true);
+      Assert.assertNull(workerGroup.get(ChannelManager.getPeerClient()));
+      if (cleanupFailure) {
+        Assert.assertEquals(1, error.getSuppressed().length);
+        Assert.assertSame(cleanupError, error.getSuppressed()[0]);
+      } else {
+        Assert.assertEquals(0, error.getSuppressed().length);
+      }
+      System.out.println("BIND_FAILURE_PROPAGATED");
+    }
+  }
+}

--- a/src/test/java/org/tron/p2p/connection/PeerServerTest.java
+++ b/src/test/java/org/tron/p2p/connection/PeerServerTest.java
@@ -1,0 +1,116 @@
+package org.tron.p2p.connection;
+
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.EventLoopGroup;
+import java.lang.reflect.Field;
+import java.net.BindException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.util.concurrent.TimeUnit;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.tron.p2p.P2pConfig;
+import org.tron.p2p.base.Parameter;
+import org.tron.p2p.connection.socket.PeerClient;
+import org.tron.p2p.connection.socket.PeerServer;
+
+public class PeerServerTest {
+
+  private static P2pConfig previousConfig;
+
+  @BeforeClass
+  public static void init() {
+    previousConfig = Parameter.p2pConfig;
+    Parameter.p2pConfig = new P2pConfig();
+    Parameter.p2pConfig.setIp("127.0.0.1");
+    Parameter.p2pConfig.setIpv6("");
+  }
+
+  @AfterClass
+  public static void destroy() {
+    Parameter.p2pConfig = previousConfig;
+  }
+
+  @Test(timeout = 15000)
+  public void occupiedPortFailsSynchronouslyAndReleasesEventLoops() throws Exception {
+    PeerServer server = new PeerServer();
+    try (ServerSocket occupied = new ServerSocket(0)) {
+      Parameter.p2pConfig.setPort(occupied.getLocalPort());
+      IllegalStateException error = Assert.assertThrows(IllegalStateException.class, server::init);
+      Assert.assertTrue(error.getCause() instanceof BindException);
+      Assert.assertTrue(error.getMessage().contains(Integer.toString(occupied.getLocalPort())));
+      assertEventLoopsTerminated(server);
+    } finally {
+      server.close();
+    }
+  }
+
+  @Test(timeout = 15000)
+  public void successfulBindReturnsBeforeCloseAndReleasesPort() throws Exception {
+    PeerServer server = new PeerServer();
+    try {
+      server.start(0);
+      ChannelFuture bind = (ChannelFuture) field(server, "channelFuture");
+      Assert.assertTrue(bind.isSuccess());
+      Assert.assertTrue(bind.channel().isActive());
+      int port = ((InetSocketAddress) bind.channel().localAddress()).getPort();
+      Assert.assertThrows(BindException.class, () -> {
+        try (ServerSocket unexpected = new ServerSocket(port)) {
+          Assert.fail("The listener must hold its port until close");
+        }
+      });
+      server.close();
+      server.close();
+      assertEventLoopsTerminated(server);
+      Assert.assertFalse(bind.channel().isOpen());
+      try (ServerSocket rebound = new ServerSocket(port)) {
+        Assert.assertTrue(rebound.isBound());
+      }
+    } finally {
+      server.close();
+    }
+  }
+
+  @Test(timeout = 15000)
+  public void startupFailurePreservesInterruptStatus() throws Exception {
+    PeerServer server = new PeerServer();
+    try (ServerSocket occupied = new ServerSocket(0)) {
+      Thread.currentThread().interrupt();
+      Assert.assertThrows(IllegalStateException.class, () -> server.start(occupied.getLocalPort()));
+      Assert.assertTrue(Thread.currentThread().isInterrupted());
+    } finally {
+      Thread.interrupted();
+      server.close();
+      assertEventLoopsTerminated(server);
+    }
+  }
+
+  @Test
+  public void disabledListenerAndUninitializedClientCanBeClosed() throws Exception {
+    Parameter.p2pConfig.setPort(0);
+    PeerServer server = new PeerServer();
+    server.init();
+    server.close();
+    Assert.assertNull(field(server, "channelFuture"));
+    Assert.assertNull(field(server, "bossGroup"));
+    Assert.assertNull(field(server, "workerGroup"));
+    new PeerClient().close();
+  }
+
+  private void assertEventLoopsTerminated(PeerServer server) throws Exception {
+    for (String name : new String[]{"bossGroup", "workerGroup"}) {
+      EventLoopGroup group = (EventLoopGroup) field(server, name);
+      Assert.assertNotNull(group);
+      Assert.assertTrue(group.terminationFuture().awaitUninterruptibly(5, TimeUnit.SECONDS));
+      Assert.assertTrue(group.isTerminated());
+    }
+  }
+
+  private Object field(PeerServer server, String name) throws Exception {
+    Field field = PeerServer.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field.get(server);
+  }
+}

--- a/src/test/java/org/tron/p2p/discover/socket/DiscoverServerTest.java
+++ b/src/test/java/org/tron/p2p/discover/socket/DiscoverServerTest.java
@@ -1,0 +1,64 @@
+package org.tron.p2p.discover.socket;
+
+import io.netty.channel.Channel;
+import java.lang.reflect.Field;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.tron.p2p.P2pConfig;
+import org.tron.p2p.base.Parameter;
+
+public class DiscoverServerTest {
+
+  @Test(timeout = 15000)
+  public void closeDuringBindReleasesChannelAndEventLoop() throws Exception {
+    P2pConfig previousConfig = Parameter.p2pConfig;
+    Parameter.p2pConfig = new P2pConfig();
+    Parameter.p2pConfig.setPort(0);
+    DiscoverServer server = new DiscoverServer();
+    CountDownLatch initializing = new CountDownLatch(1);
+    CountDownLatch continueBind = new CountDownLatch(1);
+    AtomicReference<Channel> udpChannel = new AtomicReference<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    try {
+      server.init(new EventHandler() {
+        @Override
+        public void channelActivated() {
+        }
+
+        @Override
+        public void handleEvent(UdpEvent event) {
+        }
+
+        @Override
+        public void setMessageSender(Consumer<UdpEvent> sender) {
+          try {
+            Field field = MessageHandler.class.getDeclaredField("channel");
+            field.setAccessible(true);
+            udpChannel.set((Channel) field.get(sender));
+            initializing.countDown();
+            Assert.assertTrue(continueBind.await(5, TimeUnit.SECONDS));
+          } catch (Throwable error) {
+            failure.set(error);
+          }
+        }
+      });
+      Assert.assertTrue(initializing.await(5, TimeUnit.SECONDS));
+      // Pause before bind completes, when DiscoverServer.close() cannot yet see its channel.
+      server.close();
+      continueBind.countDown();
+      Channel channel = udpChannel.get();
+      Assert.assertTrue(channel.closeFuture().await(5, TimeUnit.SECONDS));
+      Assert.assertTrue(channel.eventLoop().terminationFuture().await(5, TimeUnit.SECONDS));
+      Assert.assertFalse(channel.isOpen());
+      Assert.assertNull(failure.get());
+    } finally {
+      continueBind.countDown();
+      server.close();
+      Parameter.p2pConfig = previousConfig;
+    }
+  }
+}


### PR DESCRIPTION
**What does this PR do?**

- Propagate initial TCP and UDP listener bind failures to the P2P startup caller.
- Return from `PeerServer.start()` after a successful TCP bind without waiting for the listener to close, and include the port and original cause in bind failures.
- Wait for the result of the first UDP discovery bind while keeping later discovery restarts asynchronous.
- Clean up partially initialized services on startup failure, retaining any cleanup exception as a suppressed exception on the original failure.
- Allow cleanup before `PeerClient` initialization and handle discovery shutdown while its UDP bind is still in progress.
- Make `StartApp` report startup failures and exit with status `1`.

**Why are these changes required?**

Previously, TCP bind failures were handled on a background path while `P2pService.start()` could still report success. UDP discovery had the same issue: `DiscoverServer.init()` returned before the first UDP bind completed, and a bind failure was only logged by the discovery thread.

The startup path now waits only for the initial listener result. If the configured TCP or UDP port is already occupied, the failure reaches the caller and the existing startup cleanup path runs. Runtime discovery-socket failures and subsequent restart attempts remain asynchronous.

**This PR has been tested by:**

- Regression tests for occupied TCP and UDP ports and propagation of the original `BindException`.
- Tests for startup cleanup, suppressed cleanup failures, interrupt preservation, normal startup/shutdown, and `StartApp` exit status.
- Tests for discovery shutdown while the initial UDP bind is in progress.
- Subprocess tests verifying that failed startup releases resources and allows the JVM to exit naturally.
- `git diff --check` passed.

**Follow up**

A full java-tron process test with the updated libp2p dependency remains to be run.

**Extra details**

TCP and UDP use independent socket namespaces, so their bind failures are tested separately. The change does not alter the wire protocol or listener port configuration.
